### PR TITLE
feat: add glab CLI skill for GitLab operations

### DIFF
--- a/skills/glab/SKILL.md
+++ b/skills/glab/SKILL.md
@@ -1,0 +1,248 @@
+---
+name: glab
+description: How to use the glab CLI to work with GitLab issues, merge requests, CI/CD pipelines, and repositories. Use this skill whenever the user is working with a GitLab project (self-hosted or SaaS), mentions merge requests, GitLab issues, GitLab CI pipelines, or wants to interact with a GitLab remote. Also use this skill when the user mentions "glab", "MR", "merge request", or when you detect the git remote points to a GitLab instance (look for "gitlab" in the remote URL). This skill is the GitLab equivalent of using `gh` for GitHub -- if the project is on GitLab, use this skill instead.
+---
+
+# glab CLI Skill
+
+Use the `glab` CLI for ALL GitLab-related tasks including working with issues, merge requests, CI/CD pipelines, and releases. If given a GitLab URL, use `glab` to get the information needed.
+
+## Before you start
+
+1. **Confirm it's a GitLab project**: check `git remote -v` for "gitlab" in the URL. If so, use `glab` (not `gh`).
+2. **Verify authentication**: run `glab auth status`. If not authenticated for the relevant hostname, **stop and ask the user** -- do not proceed.
+
+## CLI-first principle
+
+**Always prefer glab subcommands** (`glab issue list`, `glab mr list`, `glab ci status`, etc.) over raw `glab api` calls. The CLI subcommands provide better output formatting, pagination, and are less error-prone. Use `glab api` **only** when no subcommand covers the operation (see the `glab api` section below).
+
+## Targeting a project
+
+Before running any `glab` command, determine the project context:
+
+1. **User provided a GitLab URL** (e.g., `https://gitlab.example.com/team/project/-/issues/42` or `https://gitlab.example.com/team/project/-/boards/1`):
+   Extract the **hostname** and **group/project path** from the URL, then use `GITLAB_HOST` + `-R`:
+   ```bash
+   # URL: https://gitlab.example.com/team/project/-/boards/123
+   # Extracted hostname: gitlab.example.com
+   # Extracted path: team/project
+   GITLAB_HOST=gitlab.example.com glab issue list -R team/project --milestone "Sprint 1" --all
+   GITLAB_HOST=gitlab.example.com glab milestone list --project team/project --state active
+   ```
+
+2. **Inside a git repo with a GitLab remote**: no `-R` or `GITLAB_HOST` needed, `glab` detects the project and hostname from the remote automatically.
+
+3. **No URL provided and not inside a git repo**: **ask the user** for the full GitLab project URL before proceeding. Do not guess or assume a project.
+
+### Self-hosted instances: always use `GITLAB_HOST`
+
+For **self-hosted GitLab instances** (anything other than `gitlab.com`), always set the `GITLAB_HOST` environment variable. This is the only reliable method that works across **all** subcommands.
+
+**Do NOT** rely on `-R <hostname>/<group>/<project>` alone -- some subcommands (e.g., `glab milestone list`) ignore the hostname in the `-R` flag and default to `gitlab.com`. Using `GITLAB_HOST` avoids this inconsistency.
+
+**Do NOT** use `--hostname` -- it is not a valid flag on most subcommands (it only works on `glab auth` and `glab api`).
+
+```bash
+# CORRECT -- works for ALL subcommands on self-hosted instances:
+GITLAB_HOST=gitlab.example.com glab issue list -R team/project --all
+GITLAB_HOST=gitlab.example.com glab milestone list --project team/project --state active
+GITLAB_HOST=gitlab.example.com glab mr list -R team/project
+
+# WRONG -- may silently hit gitlab.com instead of your self-hosted instance:
+glab milestone list -R gitlab.example.com/team/project --project team/project
+```
+
+## Handling auth errors
+
+If any `glab` command fails with "Unauthenticated", "401", "403", or "connection refused", **stop immediately**. Do NOT work around auth failures with WebFetch, curl, or `gh`. Self-hosted GitLab instances are private -- those fallbacks will also fail.
+
+Present the user with these options:
+
+### Option 1: OAuth login (preferred -- more secure, tokens auto-refresh)
+
+```bash
+glab auth login --hostname <hostname> --use-keyring
+# Select "Web" → browser opens → authorize → done
+```
+
+If OAuth fails (no OAuth app configured on the instance), fall back to a PAT.
+
+### Option 2: Personal Access Token
+
+Check git protocol to recommend minimal scopes:
+
+- **SSH users** (`git@...` remote): `api` scope is sufficient
+- **HTTPS users** (`https://...` remote): `api` + `write_repository`
+
+Tell the user to generate a token at: `https://<hostname>/-/user_settings/personal_access_tokens?scopes=api,write_repository` — recommend a short expiry (30-90 days).
+
+```bash
+glab auth login --hostname <hostname> --token <token> --use-keyring
+```
+
+### Option 3: Skip the operation
+
+**Always use `--use-keyring`** to store credentials in the OS keyring. Never store tokens in plaintext config.
+
+## Core terminology
+
+| GitHub | GitLab | CLI |
+|--------|--------|-----|
+| Pull Request | **Merge Request** | `glab mr` |
+| Gist | **Snippet** | `glab snippet` |
+| Actions | **CI/CD** | `glab ci` |
+| `OWNER/REPO` | `GROUP/PROJECT` (supports nesting: `GROUP/SUBGROUP/PROJECT`) | -- |
+| PR `#15` | MR `!15` | -- |
+
+Issues use `#`, merge requests use `!`.
+
+---
+
+## Issues
+
+```bash
+glab issue create --title "Bug: ..." --description "..." --label "type::bug,priority::high" --assignee "@me"
+glab issue list --assignee=@me                    # list my issues
+glab issue list --label="bug" --search="login"    # filter and search
+glab issue view 42 --comments                     # view with comments
+glab issue note 42 --message "Root cause found."  # add a comment
+glab issue update 42 --label "confirmed"          # update metadata
+glab issue close 42                               # close (ask confirmation first)
+glab issue reopen 42
+```
+
+### Label selection process
+
+If the user specified exact labels, use them. Otherwise:
+
+1. **Discover available labels**: `glab label list` (or `glab api projects/:id/labels` for more detail)
+2. **Propose labels that fit** the issue context -- suggest scoped labels (e.g., `priority::high`, `type::bug`) when they exist in the project. Scoped labels use `::` and auto-remove conflicting labels in the same scope.
+3. **Ask the user to confirm or adjust** before creating the issue.
+
+Do NOT invent label names. Only propose labels that actually exist in the project.
+
+**Create an MR directly from an issue**: `glab mr for 42` creates a branch and linked MR that auto-closes the issue on merge.
+
+---
+
+## Merge Requests
+
+### Creating MRs
+
+```bash
+glab mr create --title "Fix login crash" --description "Closes #42" \
+  --target-branch develop --reviewer "marco" --assignee "@me"
+glab mr create --fill              # title/description from commits
+glab mr create --draft --fill      # draft MR
+```
+
+Include `Closes #42` or `Fixes #42` in the description to auto-close issues on merge.
+
+**MR creation checklist** (follow this carefully):
+
+1. **Inspect branch state**: `git status`, `git log <base>...HEAD --oneline`, `git diff <base>...HEAD`
+2. **Draft title/description from the actual diff** -- reference specific files, functions, behaviors. Do not just restate the user's request.
+3. **Push**: `git push -u origin HEAD` if not yet pushed.
+4. **Create**: `glab mr create` with all relevant flags.
+5. **Return the MR URL** to the user.
+
+### Reviewing and managing MRs
+
+```bash
+glab mr view 15 --comments          # view MR with comments
+glab mr diff 15                     # see the diff
+glab mr list --reviewer=@me         # MRs needing my review
+glab mr checkout 15                 # checkout locally
+glab mr note 15 --message "LGTM"   # leave a comment
+glab mr approve 15                  # formal approval (separate from notes)
+glab mr revoke 15                   # revoke approval
+glab mr merge 15 --squash --remove-source-branch --when-pipeline-succeeds
+glab mr rebase 15                   # rebase onto target
+glab mr update 15 --add-label "reviewed"
+glab mr close 15                    # close without merging
+```
+
+**Code review workflow**: view MR -> read diff -> check CI (`glab ci status`) -> read comments -> leave feedback -> approve or request changes.
+
+Approval and notes are separate commands -- `glab mr approve` handles GitLab's formal approval system, `glab mr note` posts a comment.
+
+---
+
+## CI/CD
+
+```bash
+glab ci status                      # pipeline status for current branch
+glab ci list                        # recent pipelines
+glab ci trace                       # stream job logs in real-time
+glab ci run                         # trigger new pipeline
+glab ci retry <pipeline-id>         # retry failed pipeline
+glab ci cancel <pipeline-id>        # cancel running pipeline
+glab ci artifact <job-id>           # download artifacts
+glab ci lint                        # validate .gitlab-ci.yml syntax
+```
+
+Run `glab ci lint` before committing CI config changes to catch syntax errors early.
+
+---
+
+## Safety Protocol
+
+**Your default role is read-only.** Do NOT proactively suggest, offer, or execute state-changing operations. Only perform write or mutating operations when the user explicitly asks for them.
+
+### Tier 1 -- FORBIDDEN (never execute these)
+
+These commands are **never** executed, regardless of what the user asks. If the user needs one of these, explain the consequences and tell them how to run it manually.
+
+| Action | Command |
+|--------|---------|
+| Delete repo | `glab repo delete` |
+| Delete release | `glab release delete` |
+| Destructive API calls | `glab api -X DELETE ...` on critical resources |
+| Force push to default branch | `git push --force` to `main`/`master`/default |
+| Hard reset | `git reset --hard` |
+
+### Tier 2 -- EXPLICIT REQUEST ONLY (never suggest, never offer)
+
+These commands are executed **only** when the user explicitly requests them with clear intent (e.g., "merge the MR", "close issue #42"). Never propose them, never include them in automated workflows, never ask "should I merge/close this?".
+
+Before executing, **always** explain what will happen and ask for confirmation.
+
+| Action | Command |
+|--------|---------|
+| Merge MR | `glab mr merge` |
+| Close issue or MR | `glab issue close`, `glab mr close` |
+| Delete issue or MR | `glab issue delete`, `glab mr delete` |
+| Cancel pipeline | `glab ci cancel` |
+| Force push (non-default branch) | `git push --force` |
+| Skip hooks | `--no-verify` |
+
+### Tier 3 -- SAFE WITH CONFIRMATION
+
+These operations can be proposed when relevant, but require a brief confirmation before execution.
+
+| Action | Command |
+|--------|---------|
+| Rebase MR | `glab mr rebase` |
+| Update metadata (labels, assignees, etc.) | `glab mr update`, `glab issue update` |
+
+### Git safety
+
+- **Prefer `glab mr rebase`** over manual rebase + force push
+- When in doubt about target branch, check the project default rather than assuming `main`
+
+---
+
+## `glab api` -- last resort for advanced operations
+
+> **Do NOT use `glab api` when a CLI subcommand can do the job.** For issues, MRs, CI, labels -- always use the dedicated subcommands first. Use `glab api` only for operations not covered by any subcommand (e.g., project members, GraphQL queries, custom endpoints).
+
+```bash
+glab api projects/:id/members                                        # GET
+glab api -X POST projects/:id/issues -f title="New" -f description="..." # POST
+glab api -X PUT projects/:id/merge_requests/15 -f title="Updated"   # PUT
+glab api projects/:id/issues --paginate                              # paginate
+```
+
+Placeholder variables (auto-resolved inside a git repo): `:id`, `:fullpath`, `:repo`.
+
+For comprehensive API patterns (GraphQL, pagination, advanced queries), read `references/api-patterns.md`.

--- a/skills/glab/evals/evals.json
+++ b/skills/glab/evals/evals.json
@@ -1,0 +1,50 @@
+{
+  "skill_name": "glab",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "I found a bug on the login page -- when you submit an empty password field the app crashes with a 500 error instead of showing a validation message. Can you create a GitLab issue for this? Make it a high priority bug and assign it to me.",
+      "expected_output": "The agent should use `glab issue create` with a descriptive title, detailed description including steps to reproduce, appropriate labels (bug, priority::high or similar), and --assignee @me. It should NOT use `gh issue create` or any GitHub-specific tooling.",
+      "files": [],
+      "assertions": [
+        "Uses `glab issue create` (not `gh issue create` or curl to the API)",
+        "Includes a descriptive --title flag with relevant bug description",
+        "Includes a --description flag with meaningful content (steps to reproduce or context)",
+        "Uses scoped labels for priority (e.g., `priority::high`) rather than flat labels",
+        "Uses `--assignee @me` or equivalent to assign to the current user",
+        "Checks the git remote to confirm it's a GitLab project before running glab commands",
+        "Uses `--label` with a bug-related label (e.g., `bug`, `type::bug`)"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "I've been working on this branch and my changes are ready. Create a merge request that targets the develop branch. The changes fix the login validation bug from issue #42. Make sure the MR description mentions it closes that issue, and request a review from my teammate 'marco'.",
+      "expected_output": "The agent should: 1) Check git status and branch state, 2) Push the branch if needed, 3) Use `glab mr create` with --target-branch develop, a clear title, a description containing 'Closes #42', --reviewer marco. It should use GitLab MR terminology, not GitHub PR terminology.",
+      "files": [],
+      "assertions": [
+        "Uses `glab mr create` (not `gh pr create` or other GitHub tooling)",
+        "Specifies `--target-branch develop` to target the correct branch",
+        "MR description contains 'Closes #42' or 'Fixes #42' to auto-close the issue",
+        "Uses `--reviewer marco` to request review from the teammate",
+        "Checks git status and branch state before creating the MR",
+        "Pushes the branch to remote (with -u) before creating the MR",
+        "Analyzes the changes (git diff/log) to draft a meaningful MR title and description"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Can you check what's going on with merge request !15? I want to see the comments, check if the pipeline passed, and then approve it with a note saying the implementation looks solid.",
+      "expected_output": "The agent should: 1) Use `glab mr view 15 --comments` to see the MR and its comments, 2) Use `glab ci status` or check pipeline status, 3) Use `glab mr note 15` to add the comment, and 4) Use `glab mr approve 15` to approve. Commands should use the `!15` MR notation and glab (not gh).",
+      "files": [],
+      "assertions": [
+        "Uses `glab mr view 15` (or with --comments) to view the MR",
+        "Views comments on the MR using `glab mr view 15 --comments`",
+        "Checks pipeline/CI status using `glab ci status` or equivalent",
+        "Uses `glab mr approve 15` to formally approve the MR (GitLab's approval system)",
+        "Uses `glab mr note 15` to add a comment about the implementation looking solid",
+        "Treats approval and comment as separate operations (not combined into one command)",
+        "Uses glab commands throughout (not gh or curl)"
+      ]
+    }
+  ]
+}

--- a/skills/glab/references/api-patterns.md
+++ b/skills/glab/references/api-patterns.md
@@ -1,0 +1,249 @@
+# glab API Patterns Reference
+
+This file covers common `glab api` patterns for operations that go beyond the built-in subcommands.
+
+## Table of Contents
+
+1. [Authentication and basics](#authentication-and-basics)
+2. [Project information](#project-information)
+3. [Issues (advanced)](#issues-advanced)
+4. [Merge requests (advanced)](#merge-requests-advanced)
+5. [Users and members](#users-and-members)
+6. [Labels and milestones](#labels-and-milestones)
+7. [GraphQL queries](#graphql-queries)
+
+---
+
+## Authentication and basics
+
+`glab api` inherits authentication from `glab auth`. When inside a git repo, it auto-detects the GitLab instance and project.
+
+```bash
+# Test connectivity
+glab api projects/:id
+
+# Get current user
+glab api user
+```
+
+### HTTP methods
+
+```bash
+glab api PATH                        # GET (default)
+glab api -X POST PATH -f key=value   # POST with form fields
+glab api -X PUT PATH -f key=value    # PUT
+glab api -X DELETE PATH              # DELETE
+```
+
+### Passing data
+
+- `-f key=value` -- string field
+- `-F key=value` -- typed field (numbers, booleans without quotes)
+- `-F key=@file.json` -- read value from file
+- `--input file.json` -- send file as request body
+
+### Pagination
+
+```bash
+# Auto-paginate all results
+glab api projects/:id/issues --paginate
+
+# Manual pagination
+glab api "projects/:id/issues?per_page=100&page=2"
+```
+
+---
+
+## Project information
+
+```bash
+# Get project details
+glab api projects/:id
+
+# List project members
+glab api projects/:id/members/all
+
+# Get project variables (CI/CD)
+glab api projects/:id/variables
+
+# List project branches
+glab api projects/:id/repository/branches
+
+# Get default branch
+glab api projects/:id | jq '.default_branch'
+
+# List project hooks/webhooks
+glab api projects/:id/hooks
+```
+
+---
+
+## Issues (advanced)
+
+```bash
+# Get issue details with full metadata
+glab api projects/:id/issues/42
+
+# List issue comments/notes
+glab api projects/:id/issues/42/notes
+
+# Add a note with special formatting
+glab api -X POST projects/:id/issues/42/notes \
+  -f body="## Summary\nThe fix has been deployed to staging."
+
+# Create a confidential issue
+glab api -X POST projects/:id/issues \
+  -f title="Security vulnerability in auth" \
+  -f description="Details..." \
+  -F confidential=true
+
+# Set issue weight (GitLab Premium)
+glab api -X PUT projects/:id/issues/42 -F weight=5
+
+# List related issues
+glab api projects/:id/issues/42/related_merge_requests
+
+# Subscribe/unsubscribe to issue notifications
+glab api -X POST projects/:id/issues/42/subscribe
+glab api -X POST projects/:id/issues/42/unsubscribe
+
+# Set time estimate
+glab api -X POST projects/:id/issues/42/time_estimate -f duration="3h"
+
+# Log time spent
+glab api -X POST projects/:id/issues/42/add_spent_time -f duration="1h30m"
+```
+
+---
+
+## Merge requests (advanced)
+
+```bash
+# Get MR details with full metadata
+glab api projects/:id/merge_requests/15
+
+# List MR comments/discussions
+glab api projects/:id/merge_requests/15/notes
+
+# List MR changes (file-level diff summary)
+glab api projects/:id/merge_requests/15/changes
+
+# Get MR approvals status
+glab api projects/:id/merge_requests/15/approvals
+
+# Get MR approval rules
+glab api projects/:id/merge_requests/15/approval_rules
+
+# List commits in an MR
+glab api projects/:id/merge_requests/15/commits
+
+# Create a thread on a specific line of code
+glab api -X POST projects/:id/merge_requests/15/discussions \
+  -f body="This null check should handle the empty string case too." \
+  -f "position[base_sha]=abc123" \
+  -f "position[head_sha]=def456" \
+  -f "position[start_sha]=abc123" \
+  -f "position[position_type]=text" \
+  -f "position[new_path]=src/auth.py" \
+  -f "position[new_line]=42"
+
+# Check merge status / conflicts
+glab api projects/:id/merge_requests/15 | jq '{merge_status: .merge_status, has_conflicts: .has_conflicts}'
+
+# List MR pipelines
+glab api projects/:id/merge_requests/15/pipelines
+```
+
+---
+
+## Users and members
+
+```bash
+# Search for a user by username
+glab api "users?username=jdoe"
+
+# List project members with access levels
+glab api projects/:id/members/all | jq '.[] | {username: .username, access_level: .access_level}'
+
+# Access levels: 10=Guest, 20=Reporter, 30=Developer, 40=Maintainer, 50=Owner
+```
+
+---
+
+## Labels and milestones
+
+```bash
+# List all project labels
+glab api projects/:id/labels
+
+# Create a scoped label
+glab api -X POST projects/:id/labels \
+  -f name="priority::critical" \
+  -f color="#FF0000"
+
+# List milestones
+glab api projects/:id/milestones
+
+# Get issues in a milestone
+glab api "projects/:id/milestones/3/issues"
+```
+
+---
+
+## GraphQL queries
+
+For complex queries that need data from multiple resources at once, use GraphQL:
+
+```bash
+# Basic GraphQL query
+glab api graphql -f query='
+  query {
+    project(fullPath: "mygroup/myproject") {
+      name
+      description
+      mergeRequests(state: opened, first: 10) {
+        nodes {
+          iid
+          title
+          author { username }
+          approvedBy { nodes { username } }
+        }
+      }
+    }
+  }
+'
+
+# GraphQL with variables
+glab api graphql -f query='
+  query($path: ID!) {
+    project(fullPath: $path) {
+      issues(state: opened, search: "login") {
+        nodes {
+          iid
+          title
+          labels { nodes { title } }
+        }
+      }
+    }
+  }
+' -f variables='{"path": "mygroup/myproject"}'
+```
+
+### Paginated GraphQL
+
+Use `$endCursor` for pagination:
+
+```bash
+glab api graphql --paginate -f query='
+  query($endCursor: String) {
+    project(fullPath: "mygroup/myproject") {
+      issues(after: $endCursor, first: 100) {
+        pageInfo { hasNextPage endCursor }
+        nodes { iid title }
+      }
+    }
+  }
+'
+```
+
+The `--paginate` flag with `$endCursor` automatically fetches all pages.


### PR DESCRIPTION
## Summary

- Adds a new `glab` skill that teaches Copilot how to use the `glab` CLI for GitLab operations (issues, MRs, CI/CD, milestones)
- Includes API patterns reference for advanced operations (GraphQL, pagination, etc.)
- Includes eval scenarios for testing skill quality

## Key features of the skill

- **CLI-first principle**: always prefer `glab` subcommands over raw `glab api` calls
- **Self-hosted GitLab support**: documents the `GITLAB_HOST` env var pattern for reliable routing to self-hosted instances (avoids a known inconsistency where some subcommands ignore the hostname in the `-R` flag)
- **Project targeting**: smart resolution from GitLab URLs, git remotes, or prompting the user when no context is available
- **Tiered safety protocol**: three levels of command restrictions (Forbidden / Explicit request only / Safe with confirmation) to prevent accidental destructive operations
- **Auth error handling**: clear guidance for OAuth and PAT-based authentication with keyring storage

## Files

| File | Description |
|---|---|
| `skills/glab/SKILL.md` | Main skill document |
| `skills/glab/references/api-patterns.md` | Advanced `glab api` patterns (GraphQL, pagination, etc.) |
| `skills/glab/evals/evals.json` | 3 eval scenarios for skill quality testing |