### PR TITLE
feat(glab): instruct agent to always declare authorship on behalf of user

### DIFF
--- a/skills/system/glab/SKILL.md
+++ b/skills/system/glab/SKILL.md
@@ -98,6 +98,40 @@ Issues use `#`, merge requests use `!`.
 
 ---
 
+## Writing comments and notes on behalf of the user
+
+Whenever you post a comment or note on an issue or MR (via `glab issue note`, `glab mr note`, or `glab api` body fields), you **must** prepend the following header to make it clear the message was authored by an AI agent acting on behalf of the user:
+
+```
+🤖 *This comment was written by an AI agent on behalf of @<username>.*
+
+---
+```
+
+To get the current authenticated username run:
+
+```bash
+GITLAB_HOST=<hostname> glab api user --jq '.username'
+```
+
+**Example** — adding a triage note to issue #42:
+
+```bash
+GITLAB_HOST=gitlab.example.com glab issue note 42 \
+  -R group/project \
+  --message "🤖 *This comment was written by an AI agent on behalf of @alice.*
+
+---
+
+## Triage
+
+Root cause identified: ..."
+```
+
+This applies to **every** comment or note, regardless of length or context. Never skip the header.
+
+---
+
 ## Issues
 
 ```bash


### PR DESCRIPTION
## Summary

- Adds a new **"Writing comments and notes on behalf of the user"** section to the `glab` skill
- Instructs the agent to always prepend a `🤖` header to every comment or note posted via `glab issue note`, `glab mr note`, or any `glab api` body field
- Includes a helper command to retrieve the authenticated username and a concrete example

## Motivation

When an AI agent posts comments on GitLab issues or MRs on behalf of a user, it should be transparent about its authorship. The standard format adopted is:

```
🤖 *This comment was written by an AI agent on behalf of @username.*

---

[content]
```

This was validated in practice and the format was well received.