### PR TITLE
feat(glab): add authorship rule, milestone id/iid fix, and changelog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,18 @@ Content with examples, commands, code snippets...
 3. Add any bundled assets (scripts, templates, data) to the skill folder
 4. Test with GitHub Copilot
 
+## Changelog
+
+This project maintains a `CHANGELOG.md` using the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.
+There is no semantic versioning — the latest commit is always the current version. Changes are grouped by date.
+
+**Every time you make changes to this repository, you must update `CHANGELOG.md`:**
+
+- Move any relevant items from `[Unreleased]` to a dated section (e.g. `[2026-03-05]`) matching today's date, or add a new dated section if none exists for today.
+- Use the standard Keep a Changelog categories: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`.
+- Write entries from the perspective of a consumer of the skill/agent (what changed, not how).
+- The `[Unreleased]` section must always remain at the top, even if empty.
+
 ## References
 
 - [AGENTS.md specification](https://agents.md/)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+This project has no semantic versioning — the latest commit is the current version.
+Changes are grouped by date.
+
+## [Unreleased]
+
+## [2026-03-05]
+
+### Added
+
+- `glab` skill: instruct agent to always declare comment/note authorship on behalf of the user
+
+### Fixed
+
+- `glab` skill: document `id` vs `iid` milestone pitfall to prevent 404 API errors
+
+### Changed
+
+- `glab` skill: moved from `skills/gitlab/` to `skills/system/` category
+- `glab` skill: streamlined milestone `id`/`iid` section for clarity
+
+## [2026-03-04]
+
+### Added
+
+- `glab` skill: initial implementation of the `glab` CLI skill for GitLab operations
+
+### Changed
+
+- `glab` skill: moved from `skills/` root to `skills/gitlab/` category
+
+## [2026-01-08]
+
+### Added
+
+- Initial project commit with repository structure
+- LICENSE file
+- GitHub Actions workflow for Claude
+- README improvements

--- a/skills/system/glab/SKILL.md
+++ b/skills/system/glab/SKILL.md
@@ -266,6 +266,39 @@ These operations can be proposed when relevant, but require a brief confirmation
 
 ---
 
+## Milestones -- `id` vs `iid` pitfall
+
+GitLab milestones have two numeric fields that are easy to confuse:
+
+| Field | Scope | Used in API path |
+|-------|-------|-----------------|
+| `id` | **Global** (unique across all GitLab) | ✅ `projects/:id/milestones/<id>` |
+| `iid` | **Project-scoped** (e.g. "Sprint 49 is milestone 58 in this project") | ❌ will return 404 |
+
+**NEVER** use `iid` as the path parameter when calling `projects/:id/milestones/:milestone_id` — it will return a 404.
+
+**Preferred approach: always look up by title**, not by numeric ID:
+
+```bash
+# CORRECT -- search by title, avoids id/iid confusion entirely:
+GITLAB_HOST=gitlab.example.com glab api "projects/group%2Frepo/milestones?title=Sprint+49"
+
+# CORRECT -- if you already have the global id from a previous call, use it:
+GITLAB_HOST=gitlab.example.com glab api "projects/group%2Frepo/milestones/551"  # 551 = global id
+
+# WRONG -- iid (project-scoped) used as path param → 404:
+GITLAB_HOST=gitlab.example.com glab api "projects/group%2Frepo/milestones/58"   # 58 = iid, NOT id
+```
+
+When you receive milestone data (e.g. from an issues list or milestone search), always note which field is `id` and which is `iid`:
+
+```json
+{ "id": 551, "iid": 58, "title": "Sprint 49" }
+        ^^^--- use this in API paths
+```
+
+---
+
 ## `glab api` -- last resort for advanced operations
 
 > **Do NOT use `glab api` when a CLI subcommand can do the job.** For issues, MRs, CI, labels -- always use the dedicated subcommands first. Use `glab api` only for operations not covered by any subcommand (e.g., project members, GraphQL queries, custom endpoints).

--- a/skills/system/glab/SKILL.md
+++ b/skills/system/glab/SKILL.md
@@ -266,36 +266,20 @@ These operations can be proposed when relevant, but require a brief confirmation
 
 ---
 
-## Milestones -- `id` vs `iid` pitfall
+## Milestones -- `id` vs `iid`
 
-GitLab milestones have two numeric fields that are easy to confuse:
-
-| Field | Scope | Used in API path |
-|-------|-------|-----------------|
-| `id` | **Global** (unique across all GitLab) | ✅ `projects/:id/milestones/<id>` |
-| `iid` | **Project-scoped** (e.g. "Sprint 49 is milestone 58 in this project") | ❌ will return 404 |
-
-**NEVER** use `iid` as the path parameter when calling `projects/:id/milestones/:milestone_id` — it will return a 404.
-
-**Preferred approach: always look up by title**, not by numeric ID:
+Always look up milestones **by title**, not by numeric ID — this avoids the `id`/`iid` confusion entirely:
 
 ```bash
-# CORRECT -- search by title, avoids id/iid confusion entirely:
+# CORRECT -- lookup by title:
 GITLAB_HOST=gitlab.example.com glab api "projects/group%2Frepo/milestones?title=Sprint+49"
 
-# CORRECT -- if you already have the global id from a previous call, use it:
-GITLAB_HOST=gitlab.example.com glab api "projects/group%2Frepo/milestones/551"  # 551 = global id
-
 # WRONG -- iid (project-scoped) used as path param → 404:
-GITLAB_HOST=gitlab.example.com glab api "projects/group%2Frepo/milestones/58"   # 58 = iid, NOT id
+GITLAB_HOST=gitlab.example.com glab api "projects/group%2Frepo/milestones/58"
 ```
 
-When you receive milestone data (e.g. from an issues list or milestone search), always note which field is `id` and which is `iid`:
-
-```json
-{ "id": 551, "iid": 58, "title": "Sprint 49" }
-        ^^^--- use this in API paths
-```
+If you must use a numeric ID, use the global `id` field (not `iid`) from the API response:
+`{ "id": 551, "iid": 58 }` → use `551` in the path, never `58`.
 
 ---
 


### PR DESCRIPTION
## Summary

- Add rule to `glab` skill requiring agents to always declare comment/note authorship on behalf of the user
- Document the `id` vs `iid` milestone pitfall to prevent 404 API errors (streamlined for clarity)
- Introduce `CHANGELOG.md` (Keep a Changelog format, date-based) and enforce changelog updates via `AGENTS.md`