### PR TITLE
fix(glab): trigger skill on GitLab URLs and block WebFetch fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ Changes are grouped by date.
 
 ## [Unreleased]
 
+## [2026-03-06]
+
+### Changed
+
+- `glab` skill: prioritize GitLab URL detection in skill description to ensure automatic triggering when users paste GitLab links
+
+### Added
+
+- `glab` skill: explicit instruction to never use WebFetch/curl on GitLab URLs (added to "Before you start" section)
+- `glab` skill: eval for GitLab URL-based MR explanation scenario
+
 ## [2026-03-05]
 
 ### Added

--- a/skills/system/glab/SKILL.md
+++ b/skills/system/glab/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: glab
-description: How to use the glab CLI to work with GitLab issues, merge requests, CI/CD pipelines, and repositories. Use this skill whenever the user is working with a GitLab project (self-hosted or SaaS), mentions merge requests, GitLab issues, GitLab CI pipelines, or wants to interact with a GitLab remote. Also use this skill when the user mentions "glab", "MR", "merge request", or when you detect the git remote points to a GitLab instance (look for "gitlab" in the remote URL). This skill is the GitLab equivalent of using `gh` for GitHub -- if the project is on GitLab, use this skill instead.
+description: How to use the glab CLI to work with GitLab issues, merge requests, CI/CD pipelines, and repositories. Use this skill whenever the user provides a URL containing "gitlab" in the hostname (e.g., gitlab.com, gitlab.example.com), mentions merge requests, GitLab issues, GitLab CI pipelines, or wants to interact with a GitLab remote. Also use this skill when the user mentions "glab", "MR", "merge request", or when you detect the git remote points to a GitLab instance (look for "gitlab" in the remote URL). This skill is the GitLab equivalent of using `gh` for GitHub -- if the project is on GitLab, use this skill instead.
 ---
 
 # glab CLI Skill
@@ -9,8 +9,9 @@ Use the `glab` CLI for ALL GitLab-related tasks including working with issues, m
 
 ## Before you start
 
-1. **Confirm it's a GitLab project**: check `git remote -v` for "gitlab" in the URL. If so, use `glab` (not `gh`).
-2. **Verify authentication**: run `glab auth status`. If not authenticated for the relevant hostname, **stop and ask the user** -- do not proceed.
+1. **Detect GitLab URLs**: If the user provided a URL containing "gitlab" in the hostname, this is a GitLab resource. Do NOT use WebFetch, curl, or browser-based tools -- GitLab instances require authentication that only `glab` can provide. Extract the hostname and project path from the URL and proceed with `glab` commands.
+2. **Confirm it's a GitLab project**: check `git remote -v` for "gitlab" in the URL. If so, use `glab` (not `gh`).
+3. **Verify authentication**: run `glab auth status`. If not authenticated for the relevant hostname, **stop and ask the user** -- do not proceed.
 
 ## CLI-first principle
 

--- a/skills/system/glab/evals/evals.json
+++ b/skills/system/glab/evals/evals.json
@@ -45,6 +45,21 @@
         "Treats approval and comment as separate operations (not combined into one command)",
         "Uses glab commands throughout (not gh or curl)"
       ]
+    },
+    {
+      "id": 4,
+      "prompt": "Can you explain me this MR https://gitlab.sparkfabrik.com/team/project/-/merge_requests/67/diffs?",
+      "expected_output": "The agent should load the glab skill immediately upon seeing the GitLab URL, extract hostname and project path, verify auth, and use glab mr view and glab mr diff to fetch MR details. It should NOT attempt WebFetch, curl, or any browser-based approach.",
+      "files": [],
+      "assertions": [
+        "Does NOT attempt WebFetch or curl on the GitLab URL",
+        "Extracts the hostname (gitlab.sparkfabrik.com) from the URL",
+        "Extracts the project path (team/project) from the URL",
+        "Sets GITLAB_HOST=gitlab.sparkfabrik.com for the self-hosted instance",
+        "Uses `glab mr view` with -R flag and correct project path",
+        "Uses `glab mr diff` to retrieve the changes",
+        "Provides a clear summary/explanation of the MR to the user"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

- The `glab` skill was not automatically loading when a user pasted a GitLab URL (e.g., `https://gitlab.sparkfabrik.com/.../-/merge_requests/67/diffs`). The agent would fall back to `WebFetch`, which hits a login wall on private instances.
- Root cause: the skill description had no URL-based trigger condition, only keyword-based ones ("glab", "MR", "merge request").

## Changes

- **`skills/system/glab/SKILL.md`**: updated frontmatter description to add "user provides a URL containing 'gitlab' in the hostname" as the first trigger condition; added step 1 in "Before you start" explicitly forbidding WebFetch/curl on GitLab URLs
- **`skills/system/glab/evals/evals.json`**: added eval #4 covering the GitLab URL → MR explanation scenario
- **`CHANGELOG.md`**: updated for 2026-03-06