### PR TITLE
fix(glab): correct CI/CD pipeline monitoring documentation

### DIFF
--- a/skills/system/glab/SKILL.md
+++ b/skills/system/glab/SKILL.md
@@ -234,10 +234,15 @@ Approval and notes are separate commands -- `glab mr approve` handles GitLab's f
 ## CI/CD
 
 ```bash
-glab ci status                      # pipeline status for current branch (see caveats below)
+glab ci status                      # pipeline status for current branch
+glab ci status --branch main        # pipeline status for a specific branch
+glab ci status --branch main --live # stream status in real-time until pipeline completes
 glab ci list                        # recent pipelines for current branch/project
 glab ci list --per-page 10          # show more pipelines
-glab ci trace                       # stream logs of the active job on current branch (see caveats below)
+glab ci trace                       # stream logs of the active job on current branch
+glab ci trace --branch main         # stream logs for a specific branch
+glab ci trace --branch main -p <id> # stream logs for a specific pipeline ID
+glab ci trace <job-name>            # stream logs for a specific job by name
 glab ci run                         # trigger new pipeline
 glab ci retry <pipeline-id>         # retry failed pipeline
 glab ci cancel <pipeline-id>        # cancel running pipeline
@@ -247,39 +252,37 @@ glab ci lint                        # validate .gitlab-ci.yml syntax
 
 Run `glab ci lint` before committing CI config changes to catch syntax errors early.
 
-### Caveats
+### Branch targeting
 
-**`glab ci status` only works when there is an active pipeline for the current branch OR an open MR associated with it.** On long-lived branches like `main` where no MR is open, it will fail with:
-```
-✘ no pipeline found for branch main and failed to find associated merge request
-```
-Use `glab ci list` instead — it always works and shows recent pipeline history.
+`glab ci status` and `glab ci trace` default to the **current git branch**. When monitoring pipelines on other branches (e.g., `main` after a push), use `--branch`:
 
-**`glab ci trace` does not accept a `--pipeline <id>` flag** — it traces the active job on the *current branch* interactively. To inspect jobs of a specific pipeline by ID, use the API (see pattern below).
+```bash
+glab ci status --branch main              # one-shot status check
+glab ci status --branch main --live       # stream until pipeline finishes
+glab ci trace --branch main               # stream active job logs on main
+```
+
+Without `--branch`, these commands look for a pipeline on the current branch, and may fail if none exists.
 
 ### Monitoring a specific pipeline
 
-When you need to check or poll a specific pipeline (e.g., after a push to `main`):
+**Preferred: `--live` flag** — streams pipeline status in real-time until the pipeline completes (success, failed, or canceled). No polling loop needed:
+
+```bash
+glab ci status --branch main --live
+```
+
+**For job-level detail** within a specific pipeline:
 
 ```bash
 # 1. Find the pipeline ID
 glab ci list --per-page 5
 
-# 2. Check individual job statuses within that pipeline
+# 2. Stream logs of a specific pipeline
+glab ci trace --branch main --pipeline-id <pipeline-id>
+
+# 3. Check individual job statuses via API (when you need structured data)
 glab api "projects/:id/pipelines/<pipeline-id>/jobs" | jq '.[] | {name: .name, status: .status, stage: .stage}'
-
-# 3. Poll overall pipeline status until success/failed
-glab api "projects/:id/pipelines/<pipeline-id>" | jq -r '.status'
-```
-
-Polling loop example:
-```bash
-for i in $(seq 1 20); do
-  STATUS=$(glab api "projects/:id/pipelines/<pipeline-id>" | jq -r '.status')
-  echo "$(date +%H:%M:%S) $STATUS"
-  [ "$STATUS" = "success" ] || [ "$STATUS" = "failed" ] && break
-  sleep 30
-done
 ```
 
 ---

--- a/skills/system/glab/SKILL.md
+++ b/skills/system/glab/SKILL.md
@@ -172,7 +172,7 @@ Before creating any issue, check for templates:
 3. **Fetch the selected template**: `glab api projects/:id/templates/issues/<key>` -- returns `{name, content}` with the full markdown body.
 4. **Fill in the template**: use the template content as the issue description. Ask the user for any information the template sections require that they haven't provided yet.
 
-Note: `glab api` does not support `--jq` -- pipe to `jq` if you need to filter fields.
+Note: `glab api` does not support a `--jq` flag — pipe output to `jq` to filter fields: `glab api projects/:id/templates/issues | jq '.[].name'`.
 
 ### Label selection process
 
@@ -234,9 +234,10 @@ Approval and notes are separate commands -- `glab mr approve` handles GitLab's f
 ## CI/CD
 
 ```bash
-glab ci status                      # pipeline status for current branch
-glab ci list                        # recent pipelines
-glab ci trace                       # stream job logs in real-time
+glab ci status                      # pipeline status for current branch (see caveats below)
+glab ci list                        # recent pipelines for current branch/project
+glab ci list --per-page 10          # show more pipelines
+glab ci trace                       # stream logs of the active job on current branch (see caveats below)
 glab ci run                         # trigger new pipeline
 glab ci retry <pipeline-id>         # retry failed pipeline
 glab ci cancel <pipeline-id>        # cancel running pipeline
@@ -245,6 +246,41 @@ glab ci lint                        # validate .gitlab-ci.yml syntax
 ```
 
 Run `glab ci lint` before committing CI config changes to catch syntax errors early.
+
+### Caveats
+
+**`glab ci status` only works when there is an active pipeline for the current branch OR an open MR associated with it.** On long-lived branches like `main` where no MR is open, it will fail with:
+```
+✘ no pipeline found for branch main and failed to find associated merge request
+```
+Use `glab ci list` instead — it always works and shows recent pipeline history.
+
+**`glab ci trace` does not accept a `--pipeline <id>` flag** — it traces the active job on the *current branch* interactively. To inspect jobs of a specific pipeline by ID, use the API (see pattern below).
+
+### Monitoring a specific pipeline
+
+When you need to check or poll a specific pipeline (e.g., after a push to `main`):
+
+```bash
+# 1. Find the pipeline ID
+glab ci list --per-page 5
+
+# 2. Check individual job statuses within that pipeline
+glab api "projects/:id/pipelines/<pipeline-id>/jobs" | jq '.[] | {name: .name, status: .status, stage: .stage}'
+
+# 3. Poll overall pipeline status until success/failed
+glab api "projects/:id/pipelines/<pipeline-id>" | jq -r '.status'
+```
+
+Polling loop example:
+```bash
+for i in $(seq 1 20); do
+  STATUS=$(glab api "projects/:id/pipelines/<pipeline-id>" | jq -r '.status')
+  echo "$(date +%H:%M:%S) $STATUS"
+  [ "$STATUS" = "success" ] || [ "$STATUS" = "failed" ] && break
+  sleep 30
+done
+```
 
 ---
 

--- a/skills/system/glab/evals/evals.json
+++ b/skills/system/glab/evals/evals.json
@@ -76,6 +76,72 @@
         "Asks the user for information required by the template sections",
         "Does NOT skip the template check and jump straight to `glab issue create`"
       ]
+    },
+    {
+      "id": 6,
+      "prompt": "I just pushed a commit to main on our GitLab project and I want to watch the pipeline run. Can you monitor it and let me know when it finishes?",
+      "expected_output": "The agent should use `glab ci status --branch main --live` to stream pipeline status in real-time until the pipeline completes. It should NOT fall back to a manual polling loop with `glab api` and `sleep`, and should NOT claim that `glab ci status` doesn't work on main.",
+      "files": [],
+      "assertions": [
+        "Uses `--branch main` flag to target the main branch pipeline",
+        "Uses `--live` flag to stream status in real-time until completion",
+        "Does NOT use a manual polling loop with `glab api` + `sleep`",
+        "Does NOT claim `glab ci status` doesn't work on main or long-lived branches",
+        "Uses `glab ci status` (not raw API calls) as the primary approach",
+        "Runs `glab ci status --branch main --live` or equivalent combination"
+      ]
+    },
+    {
+      "id": 7,
+      "prompt": "The pipeline on main failed and I need to figure out what went wrong. I think it was the deploy job. Can you show me the logs from that specific pipeline? The pipeline ID is 243296.",
+      "expected_output": "The agent should use `glab ci trace` with `--branch main` and `--pipeline-id 243296` to stream the logs. It may also use `glab api` for job-level inspection, but should prefer CLI subcommands first. It should NOT claim that `glab ci trace` doesn't accept a pipeline ID flag.",
+      "files": [],
+      "assertions": [
+        "Uses `glab ci trace` with `--pipeline-id` or `-p` flag to target the specific pipeline",
+        "Uses `--branch main` to specify the branch",
+        "Does NOT claim `glab ci trace` doesn't accept a pipeline flag",
+        "May use `glab api projects/:id/pipelines/243296/jobs` for job-level detail, but as supplementary",
+        "Prefers CLI subcommands (`glab ci trace`) over raw API calls for the primary operation",
+        "References the deploy job specifically in its approach"
+      ]
+    },
+    {
+      "id": 8,
+      "prompt": "I'm on the feature/auth branch right now but I want to check if there's a running pipeline on main. Can you check and wait for it to finish?",
+      "expected_output": "The agent should use `glab ci status --branch main` (not rely on the current branch) and `--live` to wait for completion. It should explicitly use `--branch main` since the user is on a different branch.",
+      "files": [],
+      "assertions": [
+        "Uses `--branch main` flag explicitly (since user is on feature/auth, not main)",
+        "Uses `--live` flag to wait for the pipeline to complete",
+        "Does NOT omit the --branch flag (which would look at feature/auth instead of main)",
+        "Uses `glab ci status` as the primary command",
+        "Does NOT fall back to a polling loop as the first approach"
+      ]
+    },
+    {
+      "id": 9,
+      "prompt": "Can you monitor pipeline #12345 on our GitLab project? I need to know when it completes and whether it passed or failed.",
+      "expected_output": "The agent should use `glab ci trace --pipeline-id 12345` or `glab ci status --live` combined with checking the specific pipeline. It should use CLI subcommands preferentially over raw API polling.",
+      "files": [],
+      "assertions": [
+        "References pipeline ID 12345 in the commands used",
+        "Uses `glab ci trace --pipeline-id 12345` or `glab ci status --live` as primary approach",
+        "Does NOT use only raw `glab api` calls when CLI subcommands can do the job",
+        "Reports the final status (success/failed) to the user",
+        "Does NOT use a manual `sleep` + polling loop as the primary approach"
+      ]
+    },
+    {
+      "id": 10,
+      "prompt": "Before I push my changes, can you validate my .gitlab-ci.yml to make sure there are no syntax errors?",
+      "expected_output": "The agent should use `glab ci lint` to validate the CI configuration file syntax. This is a straightforward command that should be used directly.",
+      "files": [],
+      "assertions": [
+        "Uses `glab ci lint` to validate the CI configuration",
+        "Runs the lint command before any push operation",
+        "Reports the validation result clearly to the user",
+        "Does NOT use raw API calls or other tools when `glab ci lint` exists"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Fixes incorrect documentation in the glab skill's CI/CD section that claimed `glab ci status` doesn't work on `main` and `glab ci trace` doesn't accept a pipeline flag
- Documents the correct flags: `--branch` for targeting specific branches, `--live` for real-time streaming, and `--pipeline-id` (`-p`) for tracing specific pipelines
- Replaces the manual `glab api` polling loop with the built-in `--live` flag as the preferred monitoring approach

## What was wrong

The first commit (`6b1ac7d`) added CI/CD caveats based on incomplete testing:
1. Claimed `glab ci status` fails on `main` without an open MR — actually works with `--branch main`
2. Claimed `glab ci trace` has no pipeline flag — actually accepts `--pipeline-id` (`-p`)
3. Recommended a manual polling loop with `glab api` + `sleep 30` — unnecessary when `--live` exists

## What this fixes

The second commit (`73dbb83`) corrects all three issues:
- **Branch targeting section**: documents `--branch` flag for both `glab ci status` and `glab ci trace`
- **Monitoring section**: promotes `glab ci status --branch main --live` as the preferred approach
- **Removes polling loop**: keeps `glab api` only for structured job-level data queries
- **Quick reference**: adds `--branch`, `--live`, `-p` examples to the command cheatsheet at the top