### PR TITLE
fix: correct glab api --jq flag usage in glab skill

### DIFF
--- a/skills/system/glab/SKILL.md
+++ b/skills/system/glab/SKILL.md
@@ -112,8 +112,10 @@ Whenever you create or post content on GitLab on behalf of the user — includin
 To get the current authenticated username run:
 
 ```bash
-GITLAB_HOST=<hostname> glab api user --jq '.username'
+GITLAB_HOST=<hostname> glab api user | jq -r '.username'
 ```
+
+> **Note:** `glab api` does not support `--jq` (that's a `gh` feature). Always pipe to `jq` instead.
 
 **Example** — creating an MR:
 
@@ -172,7 +174,7 @@ Before creating any issue, check for templates:
 3. **Fetch the selected template**: `glab api projects/:id/templates/issues/<key>` -- returns `{name, content}` with the full markdown body.
 4. **Fill in the template**: use the template content as the issue description. Ask the user for any information the template sections require that they haven't provided yet.
 
-Note: `glab api` does not support a `--jq` flag — pipe output to `jq` to filter fields: `glab api projects/:id/templates/issues | jq '.[].name'`.
+To list just the template names: `glab api projects/:id/templates/issues | jq '.[].name'`.
 
 ### Label selection process
 


### PR DESCRIPTION
### **User description**
## Summary

- `glab api` does not support the `--jq` flag — that's a `gh` (GitHub CLI) feature. The skill was telling agents to run `glab api user --jq '.username'` which always fails with `Unknown flag: --jq`
- Replaced with `glab api user | jq -r '.username'` (piping to external `jq`, consistent with how `api-patterns.md` already does it)
- Added an inline warning note right after the username command so agents see it in context
- Removed the duplicate orphaned warning from the "Issue template selection" section (line 175) where it was easy to miss

## Before / After

```diff
-GITLAB_HOST=<hostname> glab api user --jq '.username'
+GITLAB_HOST=<hostname> glab api user | jq -r '.username'
```


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Fix incorrect `--jq` flag usage in `glab api` command

- Replace `--jq` with pipe to external `jq` command

- Add inline warning note about `--jq` incompatibility

- Remove duplicate/misplaced warning from issue templates section


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["glab api user --jq '.username'"] -- "replaced with" --> B["glab api user | jq -r '.username'"]
  C["Orphaned warning in issue templates section"] -- "removed and" --> D["Inline warning added near command"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SKILL.md</strong><dd><code>Fix incorrect `--jq` flag and consolidate warning note</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

skills/system/glab/SKILL.md

<ul><li>Replaced <code>glab api user --jq '.username'</code> with <code>glab api user | jq -r </code><br><code>'.username'</code><br> <li> Added inline note warning that <code>glab api</code> does not support <code>--jq</code> flag<br> <li> Removed duplicate/orphaned warning from the "Issue template selection" <br>section</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sf-awesome-copilot/pull/14/files#diff-84e2a4ece59b87af4b97b9aaa6ccd64e9f4abf7cc3e00eae3678e44f42740023">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

