### PR TITLE
chore: add git workflow rules requiring feature branches and PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,13 @@ System agents (`agents/system/`) support multiple tools (Copilot, OpenCode). Eac
 4. Test with GitHub Copilot
 5. **Update `SYSTEM.md`** — if the skill belongs to `system/`, add or remove it from the "Available skills" list
 
+## Git Workflow
+
+- **Never push directly to `main`.** Always create a feature branch and open a pull request.
+- Branch naming: `feat/`, `fix/`, `chore/`, `test/` prefixes with kebab-case description (e.g., `feat/glab-file-uploads`, `fix/skill-jq-flag`).
+- Commit messages: conventional commits (`feat:`, `fix:`, `chore:`, `test:`, `docs:`).
+- Always update `CHANGELOG.md` when making user-facing changes (see Changelog section below).
+
 ## Changelog
 
 This project maintains a `CHANGELOG.md` using the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ Changes are grouped by date.
 
 ## [Unreleased]
 
+## [2026-03-18]
+
+### Added
+
+- `glab` skill: file upload workflow documentation (curl-based workaround for glab api multipart limitation, OAuth vs PAT auth header guidance)
+- `glab` skill: two new eval cases for file upload scenarios (image to MR, PDF to issue)
+- `AGENTS.md`: git workflow rules requiring feature branches and pull requests
+
+### Changed
+
+- `glab` skill: clarified `-F key=@file` in api-patterns.md to warn it reads as string, not multipart
+
 ## [2026-03-07]
 
 ### Added


### PR DESCRIPTION
🤖 *This was written by an AI agent on behalf of @paolomainardi.*

---

## Summary

- Adds a "Git Workflow" section to `AGENTS.md` requiring feature branches and PRs (no direct pushes to `main`)
- Documents branch naming conventions (`feat/`, `fix/`, `chore/`, `test/`) and conventional commit style
- Updates `CHANGELOG.md` with today's changes (file upload docs, evals, and this rule)

## Context

The glab skill file upload changes (`898ede3`) were accidentally pushed directly to `main`. This PR adds the guardrail to prevent that from happening again.