### PR TITLE
feat(gh): add GitHub CLI skill for issues, PRs, Actions, and reviews

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,7 @@ System agents (`agents/system/`) support multiple tools (Copilot, OpenCode). Eac
 3. Add any bundled assets (scripts, templates, data) to the skill folder
 4. Test with GitHub Copilot
 5. **Update `SYSTEM.md`** — if the skill belongs to `system/`, add or remove it from the "Available skills" list
+6. **Update `README.md`** — add or remove the skill from the skills table
 
 ## Git Workflow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,7 @@ There is no semantic versioning — the latest commit is always the current vers
 - Move any relevant items from `[Unreleased]` to a dated section (e.g. `[2026-03-05]`) matching today's date, or add a new dated section if none exists for today.
 - Use the standard Keep a Changelog categories: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`.
 - Write entries from the perspective of a consumer of the skill/agent (what changed, not how).
+- Keep it concise: 1-2 entries per skill/agent per date section. Consolidate related changes into a single entry rather than listing each sub-feature separately.
 - The `[Unreleased]` section must always remain at the top, even if empty.
 
 ## References

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ Changes are grouped by date.
 
 ## [Unreleased]
 
+## [2026-03-20]
+
+### Added
+
+- `gh` skill: initial implementation of the GitHub CLI skill for issues, pull requests, Actions workflows, releases, search, and repository operations
+- `gh` skill: PR comments and reviews section covering top-level comments, formal reviews, inline code comments, and threaded reply workflows via `gh api`
+- `gh` skill: three-tier safety protocol (Forbidden, Explicit Request Only, Safe With Confirmation) covering `gh`-specific risks including `--admin` merge bypass, secrets/variables management, and workflow control
+- `gh` skill: AI attribution header policy for all agent-created content
+- `gh` skill: API patterns reference with `--jq` filtering, GraphQL, pagination, and review comment thread management
+- `gh` skill: 12 eval scenarios covering issue/PR creation, CI monitoring, review comment replies, releases, search, and URL handling
+- `SYSTEM.md`: added `gh` to available skills list
+
 ## [2026-03-18]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ Changes are grouped by date.
 - `gh` skill: 12 eval scenarios covering issue/PR creation, CI monitoring, review comment replies, releases, search, and URL handling
 - `SYSTEM.md`: added `gh` to available skills list
 
+### Fixed
+
+- `glab` skill: AI attribution examples now use explicit two-step username capture pattern instead of hardcoded `@alice`
+- `gh` skill: AI attribution examples use `$GH_USERNAME` variable pattern to prevent hardcoded or missing usernames
+
 ## [2026-03-18]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,18 +12,11 @@ Changes are grouped by date.
 
 ### Added
 
-- `gh` skill: initial implementation of the GitHub CLI skill for issues, pull requests, Actions workflows, releases, search, and repository operations
-- `gh` skill: PR comments and reviews section covering top-level comments, formal reviews, inline code comments, and threaded reply workflows via `gh api`
-- `gh` skill: three-tier safety protocol (Forbidden, Explicit Request Only, Safe With Confirmation) covering `gh`-specific risks including `--admin` merge bypass, secrets/variables management, and workflow control
-- `gh` skill: AI attribution header policy for all agent-created content
-- `gh` skill: API patterns reference with `--jq` filtering, GraphQL, pagination, and review comment thread management
-- `gh` skill: 12 eval scenarios covering issue/PR creation, CI monitoring, review comment replies, releases, search, and URL handling
-- `SYSTEM.md`: added `gh` to available skills list
+- `gh` skill: GitHub CLI skill for issues, pull requests, Actions, releases, search, PR review comment replies, safety protocol, and API patterns reference with 12 eval scenarios
 
 ### Fixed
 
-- `glab` skill: AI attribution examples now use explicit two-step username capture pattern instead of hardcoded `@alice`
-- `gh` skill: AI attribution examples use `$GH_USERNAME` variable pattern to prevent hardcoded or missing usernames
+- `glab` skill: AI attribution examples now use explicit two-step username capture pattern instead of hardcoded placeholder
 
 ## [2026-03-18]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changes are grouped by date.
 ### Added
 
 - `gh` skill: GitHub CLI skill for issues, pull requests, Actions, releases, search, PR review comment replies, safety protocol, and API patterns reference with 12 eval scenarios
+- `README.md`: skills table and `AGENTS.md` rule to keep it updated when adding/removing skills
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ Inspired by [github/awesome-copilot](https://github.com/github/awesome-copilot/t
 
 ## Skills
 
+| Skill | Description | Path |
+|-------|-------------|------|
+| **glab** | GitLab CLI -- issues, merge requests, CI/CD pipelines, repositories | `skills/system/glab/` |
+| **gh** | GitHub CLI -- issues, pull requests, Actions, releases, PR review comments | `skills/system/gh/` |
+
 Skills are documents that provide context to Copilot on specific topics. Each skill contains:
 
 - Description and use cases

--- a/SYSTEM.md
+++ b/SYSTEM.md
@@ -43,3 +43,4 @@ Skills are installed to a shared standard path used by all coding agent tools:
 ## Available skills
 
 - **glab** -- GitLab CLI skill for working with issues, merge requests, CI/CD pipelines, and repositories via the `glab` CLI.
+- **gh** -- GitHub CLI skill for working with issues, pull requests, Actions workflows, releases, and repositories via the `gh` CLI.

--- a/skills/system/gh/SKILL.md
+++ b/skills/system/gh/SKILL.md
@@ -76,7 +76,7 @@ Issues and PRs both use `#` prefix.
 Whenever you create or post content on GitHub on behalf of the user -- including **PR descriptions** (`gh pr create`), **issue descriptions** (`gh issue create`), **comments** (`gh pr comment`, `gh issue comment`), **reviews** (`gh pr review`), or **`gh api` body fields** -- you **must** prepend the following header to make it clear the content was authored by an AI agent acting on behalf of the user:
 
 ```
-> *This was written by an AI agent on behalf of @<username>.*
+🤖 *This was written by an AI agent on behalf of @<username>.*
 
 ---
 ```
@@ -92,7 +92,7 @@ gh api user --jq '.login'
 ```bash
 gh pr create \
   --title "feat: add dark mode" \
-  --body "> *This was written by an AI agent on behalf of @alice.*
+  --body "🤖 *This was written by an AI agent on behalf of @alice.*
 
 ---
 
@@ -106,7 +106,7 @@ gh pr create \
 
 ```bash
 gh issue comment 42 \
-  --body "> *This was written by an AI agent on behalf of @alice.*
+  --body "🤖 *This was written by an AI agent on behalf of @alice.*
 
 ---
 
@@ -260,7 +260,7 @@ Use the dedicated replies endpoint:
 
 ```bash
 gh api -X POST repos/{owner}/{repo}/pulls/15/comments/<comment_id>/replies \
-  -f body="> *This was written by an AI agent on behalf of @alice.*
+  -f body="🤖 *This was written by an AI agent on behalf of @alice.*
 
 ---
 

--- a/skills/system/gh/SKILL.md
+++ b/skills/system/gh/SKILL.md
@@ -81,18 +81,16 @@ Whenever you create or post content on GitHub on behalf of the user -- including
 ---
 ```
 
-To get the current authenticated username:
+Before writing any content, **always fetch the username first** and embed it in the header. Do not hardcode a username or leave the placeholder unfilled:
 
 ```bash
-gh api user --jq '.login'
-```
+# Step 1: fetch the username (do this once per session)
+GH_USERNAME=$(gh api user --jq '.login')
 
-**Example** -- creating a PR:
-
-```bash
+# Step 2: use it in the content
 gh pr create \
   --title "feat: add dark mode" \
-  --body "🤖 *This was written by an AI agent on behalf of @alice.*
+  --body "🤖 *This was written by an AI agent on behalf of @${GH_USERNAME}.*
 
 ---
 
@@ -106,7 +104,7 @@ gh pr create \
 
 ```bash
 gh issue comment 42 \
-  --body "🤖 *This was written by an AI agent on behalf of @alice.*
+  --body "🤖 *This was written by an AI agent on behalf of @${GH_USERNAME}.*
 
 ---
 
@@ -260,7 +258,7 @@ Use the dedicated replies endpoint:
 
 ```bash
 gh api -X POST repos/{owner}/{repo}/pulls/15/comments/<comment_id>/replies \
-  -f body="🤖 *This was written by an AI agent on behalf of @alice.*
+  -f body="🤖 *This was written by an AI agent on behalf of @${GH_USERNAME}.*
 
 ---
 

--- a/skills/system/gh/SKILL.md
+++ b/skills/system/gh/SKILL.md
@@ -1,0 +1,561 @@
+---
+name: gh
+description: 'How to use the GitHub CLI (gh) to work with GitHub issues, pull requests, Actions workflows, releases, and repositories. Use this skill whenever the user provides a URL containing "github.com" in the hostname, mentions pull requests, GitHub issues, GitHub Actions, or wants to interact with a GitHub remote. Also use this skill when the user mentions "gh", "PR", "pull request", or when you detect the git remote points to a GitHub instance (look for "github" in the remote URL). This skill is the GitHub equivalent of using `glab` for GitLab -- if the project is on GitHub, use this skill instead.'
+---
+
+# gh CLI Skill
+
+Use the `gh` CLI for ALL GitHub-related tasks including working with issues, pull requests, Actions workflows, releases, and repositories. If given a GitHub URL, use `gh` to get the information needed.
+
+## Before you start
+
+1. **Detect GitHub URLs**: if the user provided a URL containing "github.com", this is a GitHub resource. Extract the owner and repo from the URL and proceed with `gh` commands using `-R owner/repo`.
+2. **Confirm it's a GitHub project**: check `git remote -v` for "github" in the URL. If so, use `gh` (not `glab`).
+3. **Verify authentication**: run `gh auth status`. If not authenticated, **stop and ask the user** -- do not proceed.
+
+## CLI-first principle
+
+**Always prefer gh subcommands** (`gh issue list`, `gh pr list`, `gh run list`, etc.) over raw `gh api` calls. The CLI subcommands provide better output formatting, pagination, and are less error-prone. Use `gh api` **only** when no subcommand covers the operation (see the `gh api` section below).
+
+## Targeting a repository
+
+Before running any `gh` command, determine the repository context:
+
+1. **User provided a GitHub URL** (e.g., `https://github.com/owner/repo/issues/42` or `https://github.com/owner/repo/pull/15`):
+   Extract the **owner/repo** from the URL, then use `-R`:
+   ```bash
+   # URL: https://github.com/acme/webapp/pull/15
+   # Extracted: acme/webapp
+   gh pr view 15 -R acme/webapp
+   gh issue list -R acme/webapp --label "bug"
+   ```
+
+2. **Inside a git repo with a GitHub remote**: no `-R` needed, `gh` detects the repository from the remote automatically.
+
+3. **No URL provided and not inside a git repo**: **ask the user** for the full GitHub repository URL before proceeding. Do not guess or assume a repository.
+
+## Handling auth errors
+
+If any `gh` command fails with "authentication", "401", "403", or "could not determine", **stop immediately**. Do NOT work around auth failures with WebFetch, curl, or `glab`.
+
+Present the user with these options:
+
+### Option 1: Browser login (preferred -- more secure, tokens auto-refresh)
+
+```bash
+gh auth login --web
+# Browser opens -> authorize -> done
+```
+
+### Option 2: Personal Access Token
+
+Tell the user to generate a token at: `https://github.com/settings/tokens?type=beta` -- recommend fine-grained tokens with minimal scopes and a short expiry (30-90 days).
+
+```bash
+gh auth login --with-token < token.txt
+```
+
+### Option 3: Skip the operation
+
+## Core terminology
+
+| GitLab | GitHub | CLI |
+|--------|--------|-----|
+| Merge Request | **Pull Request** | `gh pr` |
+| Snippet | **Gist** | `gh gist` |
+| CI/CD | **Actions** | `gh run`, `gh workflow` |
+| `GROUP/PROJECT` (supports nesting) | `OWNER/REPO` | -- |
+| MR `!15` | PR `#15` | -- |
+
+Issues and PRs both use `#` prefix.
+
+---
+
+## Writing on behalf of the user
+
+Whenever you create or post content on GitHub on behalf of the user -- including **PR descriptions** (`gh pr create`), **issue descriptions** (`gh issue create`), **comments** (`gh pr comment`, `gh issue comment`), **reviews** (`gh pr review`), or **`gh api` body fields** -- you **must** prepend the following header to make it clear the content was authored by an AI agent acting on behalf of the user:
+
+```
+> *This was written by an AI agent on behalf of @<username>.*
+
+---
+```
+
+To get the current authenticated username:
+
+```bash
+gh api user --jq '.login'
+```
+
+**Example** -- creating a PR:
+
+```bash
+gh pr create \
+  --title "feat: add dark mode" \
+  --body "> *This was written by an AI agent on behalf of @alice.*
+
+---
+
+## Summary
+
+- Adds dark mode toggle to settings page
+- ..."
+```
+
+**Example** -- adding a comment to issue #42:
+
+```bash
+gh issue comment 42 \
+  --body "> *This was written by an AI agent on behalf of @alice.*
+
+---
+
+## Triage
+
+Root cause identified: ..."
+```
+
+This applies to **every** piece of content the agent creates, regardless of length or context. Never skip the header.
+
+---
+
+## Issues
+
+```bash
+gh issue create --title "Bug: ..." --body "..." --label bug --label "high-priority" --assignee "@me"
+gh issue list --assignee @me                      # list my issues
+gh issue list --label "bug" --search "login"      # filter and search
+gh issue view 42 --comments                       # view with comments
+gh issue comment 42 --body "Root cause found."    # add a comment
+gh issue edit 42 --add-label "confirmed"          # update metadata
+gh issue close 42                                 # close (ask confirmation first)
+gh issue reopen 42
+```
+
+### Issue template selection
+
+Many GitHub projects define issue templates (stored in `.github/ISSUE_TEMPLATE/`) that encode the team's expected structure -- sections to fill, checklists, labels. Skipping these creates issues that don't match the project's conventions and forces manual cleanup.
+
+Use `--template` to select a template by name:
+
+```bash
+# List templates by checking the repository
+ls .github/ISSUE_TEMPLATE/
+# Or via API
+gh api repos/{owner}/{repo}/contents/.github/ISSUE_TEMPLATE --jq '.[].name'
+
+# Create with a template
+gh issue create --template "Bug Report" --title "Login crash on empty password"
+```
+
+If no `--template` is specified and templates exist, `gh issue create` will prompt interactively. When running non-interactively, check for templates first and ask the user which one to use.
+
+### Label selection process
+
+If the user specified exact labels, use them. Otherwise:
+
+1. **Discover available labels**: `gh label list` (or `gh label list --json name,description` for more detail)
+2. **Propose labels that fit** the issue context.
+3. **Ask the user to confirm or adjust** before creating the issue.
+
+Do NOT invent label names. Only propose labels that actually exist in the repository.
+
+### Create a branch from an issue
+
+```bash
+gh issue develop 42 --checkout              # create branch linked to issue and check it out
+gh issue develop 42 --name fix/issue-42     # custom branch name
+gh issue develop 42 --base develop          # branch from a specific base
+```
+
+---
+
+## Pull Requests
+
+### Creating PRs
+
+```bash
+gh pr create --title "Fix login crash" --body "Closes #42" \
+  --base develop --reviewer "marco" --assignee "@me"
+gh pr create --fill                   # title/description from commits
+gh pr create --fill-verbose           # commits msg+body for description
+gh pr create --draft --fill           # draft PR
+```
+
+Include `Closes #42` or `Fixes #42` in the body to auto-close issues on merge.
+
+**PR creation checklist** (follow this carefully):
+
+1. **Inspect branch state**: `git status`, `git log <base>...HEAD --oneline`, `git diff <base>...HEAD`
+2. **Draft title/description from the actual diff** -- reference specific files, functions, behaviors. Do not just restate the user's request.
+3. **Push**: `git push -u origin HEAD` if not yet pushed.
+4. **Create**: `gh pr create` with all relevant flags.
+5. **Return the PR URL** to the user.
+
+### Reviewing and managing PRs
+
+```bash
+gh pr view 15 --comments              # view PR with comments
+gh pr diff 15                         # see the diff
+gh pr diff 15 --name-only             # list changed files
+gh pr list --author @me               # my PRs
+gh pr checkout 15                     # checkout locally
+gh pr comment 15 --body "LGTM"       # leave a top-level comment
+gh pr review 15 --approve --body "Looks good"  # formal approval
+gh pr review 15 --request-changes --body "Please fix..." # request changes
+gh pr merge 15 --squash --delete-branch
+gh pr update-branch 15                # update with latest base branch
+gh pr edit 15 --add-label "reviewed"
+gh pr ready 15                        # mark draft as ready for review
+gh pr ready 15 --undo                 # convert back to draft
+gh pr close 15                        # close without merging
+```
+
+**Code review workflow**: view PR -> read diff -> check CI (`gh pr checks`) -> read comments -> leave feedback -> approve or request changes.
+
+Approval and comments are separate actions -- `gh pr review --approve` handles GitHub's formal review system, `gh pr comment` posts a timeline comment.
+
+### PR checks (CI status per PR)
+
+```bash
+gh pr checks 15                       # one-shot status
+gh pr checks 15 --watch               # stream until all checks finish
+gh pr checks 15 --watch --interval 5  # custom refresh interval
+gh pr checks 15 --required            # only show required checks
+gh pr checks 15 --fail-fast           # exit on first failure in watch mode
+```
+
+---
+
+## PR Comments and Reviews
+
+GitHub PRs have **three distinct comment types**. Using the wrong one is a common mistake -- a top-level comment when the user wanted a threaded reply to an inline review creates noise and loses context.
+
+### Comment types
+
+| Type | What it is | How to post |
+|------|-----------|-------------|
+| **Top-level comment** | Timeline comment on the PR (like an issue comment) | `gh pr comment 15 --body "..."` |
+| **Review** | Formal review: approve, request changes, or comment with a body | `gh pr review 15 --approve --body "..."` |
+| **Inline review comment** | Comment on a specific line of code, starting a thread | `gh api` (no CLI subcommand) |
+| **Reply to inline comment** | Threaded reply to an existing inline code comment | `gh api` (no CLI subcommand) |
+
+### Replying to review comments
+
+There is no `gh pr` subcommand for replying to inline code review comments. You must use `gh api`.
+
+**Step 1: List review comments to find the comment ID**
+
+```bash
+# List all review comments on PR #15
+gh api repos/{owner}/{repo}/pulls/15/comments \
+  --jq '.[] | {id, user: .user.login, path, line, body: (.body | .[0:80])}'
+```
+
+Each comment has an `id` field. Top-level review comments have no `in_reply_to_id`; replies do.
+
+**Step 2: Reply to a specific comment**
+
+Use the dedicated replies endpoint:
+
+```bash
+gh api -X POST repos/{owner}/{repo}/pulls/15/comments/<comment_id>/replies \
+  -f body="> *This was written by an AI agent on behalf of @alice.*
+
+---
+
+The null check is needed because..."
+```
+
+Constraint: **replies to replies are not supported** by the API -- you can only reply to top-level review comments (those without `in_reply_to_id`). If the comment you want to reply to is itself a reply, reply to the parent comment instead.
+
+**Step 3 (alternative): Reply using `in_reply_to`**
+
+You can also reply via the create comment endpoint with the `in_reply_to` parameter. When `in_reply_to` is set, all other parameters except `body` are ignored:
+
+```bash
+gh api -X POST repos/{owner}/{repo}/pulls/15/comments \
+  -f body="Agreed, good catch." \
+  -F in_reply_to=<comment_id>
+```
+
+### Creating a new inline review comment
+
+To start a new thread on a specific line of code:
+
+```bash
+# Get the latest commit SHA on the PR
+COMMIT_SHA=$(gh pr view 15 --json headRefOid --jq '.headRefOid')
+
+gh api -X POST repos/{owner}/{repo}/pulls/15/comments \
+  -f body="This null check should handle empty strings too." \
+  -f commit_id="$COMMIT_SHA" \
+  -f path="src/auth.ts" \
+  -F line=42 \
+  -f side="RIGHT"
+```
+
+Parameters:
+- `commit_id` (required): use the PR's HEAD commit SHA. Using an older commit may render the comment outdated.
+- `path` (required): relative file path in the repo.
+- `line` (required for line comments): line number in the diff.
+- `side`: `RIGHT` for additions (green), `LEFT` for deletions (red).
+- `start_line` + `start_side`: for multi-line comments, the first line of the range.
+
+### Responding to all open review comments
+
+When the user asks to respond to review comments on a PR, follow this workflow:
+
+1. **List all review comments**: `gh api repos/{owner}/{repo}/pulls/15/comments --jq '.[] | {id, in_reply_to_id, user: .user.login, path, line, body}'`
+2. **Filter to top-level comments** (those without `in_reply_to_id`) that haven't been addressed yet.
+3. **Present a summary** to the user: who commented, on which file/line, what they said.
+4. **Draft replies** and get user confirmation before posting.
+5. **Post replies** using the replies endpoint for each comment.
+
+Never post replies without showing them to the user first.
+
+### Editing and deleting comments
+
+`gh pr comment` and `gh issue comment` only support editing/deleting your **last** comment:
+
+```bash
+gh pr comment 15 --edit-last --body "Updated comment"   # edit your last comment
+gh pr comment 15 --delete-last                           # delete your last comment
+```
+
+To edit or delete an arbitrary comment by ID, use the API:
+
+```bash
+# Edit a PR timeline comment (issue comment)
+gh api -X PATCH repos/{owner}/{repo}/issues/comments/<comment_id> -f body="Updated"
+
+# Edit a review comment
+gh api -X PATCH repos/{owner}/{repo}/pulls/comments/<comment_id> -f body="Updated"
+
+# Delete a review comment
+gh api -X DELETE repos/{owner}/{repo}/pulls/comments/<comment_id>
+```
+
+---
+
+## GitHub Actions / CI
+
+```bash
+gh run list                             # recent runs for current branch
+gh run list --branch main               # runs on a specific branch
+gh run list --workflow "ci.yml"          # filter by workflow
+gh run list --status failure             # filter by status
+gh run view <run-id>                    # run summary
+gh run view <run-id> --verbose          # show job steps
+gh run view <run-id> --log              # full logs
+gh run view <run-id> --log-failed       # logs only for failed steps
+gh run view <run-id> --job <job-id>     # specific job
+gh run watch <run-id>                   # stream status in real-time until done
+gh run watch <run-id> --exit-status     # exit non-zero if run fails
+gh run rerun <run-id>                   # rerun entire run
+gh run rerun <run-id> --job <job-id>    # rerun specific job
+gh run cancel <run-id>                  # cancel running workflow
+gh run download <run-id>                # download artifacts
+gh run download <run-id> --name build   # download specific artifact
+```
+
+### Workflows
+
+```bash
+gh workflow list                        # list all workflows
+gh workflow view ci.yml                 # view workflow details
+gh workflow view ci.yml --yaml          # view workflow YAML
+gh workflow run ci.yml                  # trigger workflow_dispatch
+gh workflow run ci.yml --ref develop    # trigger on specific ref
+gh workflow run ci.yml -f version="1.0" -f env="prod"  # with inputs
+gh workflow enable ci.yml               # enable disabled workflow
+gh workflow disable ci.yml              # disable workflow
+```
+
+### Monitoring a run
+
+**To watch a specific run**, first find its ID, then watch it:
+
+```bash
+# Find the run ID
+gh run list --branch main --limit 1 --json databaseId --jq '.[0].databaseId'
+
+# Watch it
+gh run watch <run-id>
+
+# Or watch with compact output (only relevant/failed steps)
+gh run watch <run-id> --compact
+```
+
+`gh run watch` takes a **run ID**, not a branch name. To monitor a run on a specific branch, always look up the run ID first via `gh run list --branch <branch>`.
+
+**For PR-specific checks**, use `gh pr checks` instead -- it shows all status checks on a PR and supports `--watch`:
+
+```bash
+gh pr checks 15 --watch
+```
+
+### Viewing failed logs
+
+When a run fails, `--log-failed` is the most efficient way to see what went wrong:
+
+```bash
+gh run view <run-id> --log-failed
+```
+
+This shows only the output from failed steps, avoiding hundreds of lines of passing step output.
+
+### Actions caches
+
+```bash
+gh cache list                           # list all caches
+gh cache list --limit 50                # show more
+gh cache delete <cache-id>              # delete specific cache
+```
+
+---
+
+## Releases
+
+```bash
+gh release list                         # list releases
+gh release view v1.0.0                  # view specific release
+gh release create v1.0.0 --notes "Release notes" --title "Version 1.0.0"
+gh release create v1.0.0 --generate-notes     # auto-generate notes
+gh release create v1.0.0 --notes-file notes.md
+gh release create v1.0.0 --draft               # draft release
+gh release create v1.0.0 --prerelease          # pre-release
+gh release create v1.0.0 ./dist/*.tar.gz       # with assets
+gh release upload v1.0.0 ./file.tar.gz         # upload asset to existing release
+gh release download v1.0.0                      # download all assets
+gh release download v1.0.0 --pattern "*.tar.gz" # download matching assets
+gh release edit v1.0.0 --notes "Updated notes"
+gh release delete v1.0.0                        # delete (NEVER do this -- see Safety Protocol)
+```
+
+---
+
+## Search
+
+`gh search` lets you search across all of GitHub, not just the current repository:
+
+```bash
+gh search issues "label:bug state:open" --repo owner/repo
+gh search prs "is:open review:required" --repo owner/repo
+gh search code "TODO" --repo owner/repo
+gh search commits "fix auth" --repo owner/repo
+gh search repos "stars:>1000 language:python"
+```
+
+All search commands support `--json`, `--jq`, and `--limit` for structured output.
+
+---
+
+## Safety Protocol
+
+**Your default role is read-only.** Do NOT proactively suggest, offer, or execute state-changing operations. Only perform write or mutating operations when the user explicitly asks for them.
+
+### Tier 1 -- FORBIDDEN (never execute these)
+
+These commands are **never** executed, regardless of what the user asks. If the user needs one of these, explain the consequences and tell them how to run it manually.
+
+| Action | Command |
+|--------|---------|
+| Delete repo | `gh repo delete` |
+| Delete release | `gh release delete` |
+| Delete workflow runs | `gh run delete` |
+| Destructive API calls | `gh api -X DELETE` on critical resources |
+| Force push to default branch | `git push --force` to `main`/`master`/default |
+| Hard reset | `git reset --hard` |
+
+### Tier 2 -- EXPLICIT REQUEST ONLY (never suggest, never offer)
+
+These commands are executed **only** when the user explicitly requests them with clear intent (e.g., "merge the PR", "close issue #42"). Never propose them, never include them in automated workflows, never ask "should I merge/close this?".
+
+Before executing, **always** explain what will happen and ask for confirmation.
+
+| Action | Command |
+|--------|---------|
+| Merge PR | `gh pr merge` |
+| Merge bypassing checks | `gh pr merge --admin` (bypasses branch protection -- extra caution) |
+| Close issue or PR | `gh issue close`, `gh pr close` |
+| Delete issue | `gh issue delete` |
+| Cancel workflow run | `gh run cancel` |
+| Disable workflow | `gh workflow disable` |
+| Modify secrets | `gh secret set`, `gh secret delete` |
+| Modify variables | `gh variable set`, `gh variable delete` |
+| Delete release assets | `gh release delete-asset` |
+| Delete all caches | `gh cache delete --all` |
+| Force push (non-default branch) | `git push --force` |
+| Skip hooks | `--no-verify` |
+
+### Tier 3 -- SAFE WITH CONFIRMATION
+
+These operations can be proposed when relevant, but require a brief confirmation before execution.
+
+| Action | Command |
+|--------|---------|
+| Update PR branch | `gh pr update-branch` |
+| Update metadata (labels, assignees, etc.) | `gh pr edit`, `gh issue edit` |
+| Change draft status | `gh pr ready`, `gh pr ready --undo` |
+| Rerun workflow | `gh run rerun` |
+| Trigger workflow | `gh workflow run` |
+
+### Git safety
+
+- **Prefer `gh pr update-branch`** over manual rebase + force push
+- When in doubt about target branch, check the repo default: `gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name'`
+
+---
+
+## `gh api` -- last resort for advanced operations
+
+> **Do NOT use `gh api` when a CLI subcommand can do the job.** For issues, PRs, runs, labels -- always use the dedicated subcommands first. Use `gh api` only for operations not covered by any subcommand (e.g., review comment replies, team membership, GraphQL queries).
+
+```bash
+gh api repos/{owner}/{repo}/collaborators                              # GET
+gh api -X POST repos/{owner}/{repo}/issues -f title="New" -f body="..." # POST
+gh api -X PATCH repos/{owner}/{repo}/pulls/15 -f title="Updated"      # PATCH
+gh api repos/{owner}/{repo}/issues --paginate                          # paginate
+```
+
+### Placeholder variables
+
+Inside a git repo, `{owner}`, `{repo}`, and `{branch}` are auto-resolved:
+
+```bash
+gh api repos/{owner}/{repo}/pulls    # resolves to the current repo
+```
+
+### Native `--jq` filtering
+
+Unlike `glab` (which requires piping to external `jq`), `gh api` has **built-in `--jq` support**:
+
+```bash
+gh api repos/{owner}/{repo}/pulls --jq '.[].title'
+gh api user --jq '.login'
+gh api repos/{owner}/{repo}/contributors --jq '.[] | {login: .login, contributions: .contributions}'
+```
+
+Use `--jq` instead of piping to `jq` whenever possible -- it's faster and avoids a dependency.
+
+### GraphQL
+
+```bash
+gh api graphql -f query='
+  query {
+    repository(owner: "owner", name: "repo") {
+      pullRequests(states: OPEN, first: 10) {
+        nodes {
+          number
+          title
+          author { login }
+          reviewDecision
+        }
+      }
+    }
+  }
+'
+```
+
+For comprehensive API patterns (GraphQL, pagination, advanced queries), read `references/api-patterns.md`.

--- a/skills/system/gh/evals/evals.json
+++ b/skills/system/gh/evals/evals.json
@@ -1,0 +1,172 @@
+{
+  "skill_name": "gh",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "I found a bug on the login page -- when you submit an empty password field the app crashes with a 500 error instead of showing a validation message. Can you create a GitHub issue for this? Make it a high priority bug and assign it to me.",
+      "expected_output": "The agent should use `gh issue create` with a descriptive title, detailed description including steps to reproduce, appropriate labels (bug, high-priority or similar), and --assignee @me. It should NOT use `glab issue create` or any GitLab-specific tooling.",
+      "files": [],
+      "assertions": [
+        "Uses `gh issue create` (not `glab issue create` or curl to the API)",
+        "Includes a descriptive --title flag with relevant bug description",
+        "Includes a --body flag with meaningful content (steps to reproduce or context)",
+        "Uses `--assignee @me` or equivalent to assign to the current user",
+        "Checks the git remote to confirm it's a GitHub project before running gh commands",
+        "Uses `--label` flag (not `--labels`) with a bug-related label",
+        "Discovers available labels via `gh label list` before creating, or uses well-known labels"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "I've been working on this branch and my changes are ready. Create a pull request that targets the develop branch. The changes fix the login validation bug from issue #42. Make sure the PR description mentions it closes that issue, and request a review from my teammate 'marco'.",
+      "expected_output": "The agent should: 1) Check git status and branch state, 2) Push the branch if needed, 3) Use `gh pr create` with --base develop, a clear title, a body containing 'Closes #42', --reviewer marco. It should use GitHub PR terminology, not GitLab MR terminology.",
+      "files": [],
+      "assertions": [
+        "Uses `gh pr create` (not `glab mr create` or other GitLab tooling)",
+        "Specifies `--base develop` to target the correct branch",
+        "PR body contains 'Closes #42' or 'Fixes #42' to auto-close the issue on merge",
+        "Uses `--reviewer marco` to request review from the teammate",
+        "Checks git status and branch state before creating the PR",
+        "Pushes the branch to remote (with -u) before creating the PR",
+        "Analyzes the changes (git diff/log) to draft a meaningful PR title and description"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Can you check what's going on with PR #15? I want to see the comments, check if the CI passed, and then approve it with a note saying the implementation looks solid.",
+      "expected_output": "The agent should: 1) Use `gh pr view 15 --comments` to see the PR and its comments, 2) Use `gh pr checks 15` to check CI status, 3) Use `gh pr review 15 --approve --body '...'` to formally approve. Commands should use gh (not glab).",
+      "files": [],
+      "assertions": [
+        "Uses `gh pr view 15` (with --comments) to view the PR",
+        "Checks CI status using `gh pr checks 15` (not raw API calls)",
+        "Uses `gh pr review 15 --approve` for formal approval (GitHub's review system)",
+        "Includes `--body` with the approval note about the implementation",
+        "Uses gh commands throughout (not glab or curl)",
+        "Does NOT confuse `gh pr comment` (timeline comment) with `gh pr review --approve` (formal approval)"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "Can you explain this PR to me? https://github.com/acme/webapp/pull/67",
+      "expected_output": "The agent should extract owner/repo (acme/webapp) and PR number (67) from the URL, use `gh pr view 67 -R acme/webapp` and `gh pr diff 67 -R acme/webapp` to fetch PR details. It should NOT attempt WebFetch, curl, or any browser-based approach.",
+      "files": [],
+      "assertions": [
+        "Does NOT attempt WebFetch or curl on the GitHub URL",
+        "Extracts the owner/repo (acme/webapp) from the URL",
+        "Extracts the PR number (67) from the URL",
+        "Uses `-R acme/webapp` to target the correct repository",
+        "Uses `gh pr view` to retrieve PR details",
+        "Uses `gh pr diff` to retrieve the changes",
+        "Provides a clear summary/explanation of the PR to the user"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "I want to create an issue on this project https://github.com/acme/webapp, using the issue template. Read it and ask me questions.",
+      "expected_output": "The agent should: 1) Extract owner/repo from the URL, 2) Check for issue templates via the API or filesystem, 3) Present available templates to the user, 4) After selection, read the template and ask the user to fill in the sections.",
+      "files": [],
+      "assertions": [
+        "Checks for issue templates (either via `gh api repos/acme/webapp/contents/.github/ISSUE_TEMPLATE` or filesystem)",
+        "Uses `-R acme/webapp` to target the correct repository",
+        "Presents the list of available templates to the user as choices before proceeding",
+        "After template selection, reads the template content",
+        "Asks the user for information required by the template sections",
+        "Does NOT skip the template check and jump straight to `gh issue create`",
+        "Uses `gh issue create --template <name>` when creating the final issue"
+      ]
+    },
+    {
+      "id": 6,
+      "prompt": "I just pushed a commit to main and I want to watch the CI run. Can you monitor it and let me know when it finishes?",
+      "expected_output": "The agent should first find the run ID using `gh run list --branch main`, then use `gh run watch <run-id>` to stream status in real-time. It should NOT pass --branch to `gh run watch` (which doesn't accept it) and should NOT fall back to a polling loop.",
+      "files": [],
+      "assertions": [
+        "Uses `gh run list --branch main` to find the run ID first",
+        "Uses `gh run watch <run-id>` to stream status in real-time",
+        "Does NOT pass `--branch` directly to `gh run watch` (that flag doesn't exist)",
+        "Does NOT use a manual polling loop with `gh api` + `sleep`",
+        "Reports the final status (success/failed) to the user"
+      ]
+    },
+    {
+      "id": 7,
+      "prompt": "The CI on my PR #28 failed and I need to figure out what went wrong. Can you show me the failing logs?",
+      "expected_output": "The agent should use `gh pr checks 28` to see which checks failed, then `gh run view <run-id> --log-failed` to show only the failed step output. It should NOT dump the entire run log.",
+      "files": [],
+      "assertions": [
+        "Uses `gh pr checks 28` to identify which checks failed",
+        "Uses `gh run view <run-id> --log-failed` to show only failed step output",
+        "Does NOT dump the entire log (should use --log-failed, not --log)",
+        "Identifies the specific failing step or job",
+        "Presents the failure information clearly to the user"
+      ]
+    },
+    {
+      "id": 8,
+      "prompt": "A reviewer left an inline comment on line 42 of src/auth.ts in PR #15 asking why I'm using a null check instead of optional chaining. Can you reply to that specific comment explaining that we need to support Node 12 which doesn't have optional chaining?",
+      "expected_output": "The agent should: 1) List review comments on PR #15 via `gh api repos/{owner}/{repo}/pulls/15/comments`, 2) Find the comment on src/auth.ts line 42, 3) Reply using the replies endpoint `gh api -X POST .../comments/<id>/replies`. It should NOT use `gh pr comment` (that creates a top-level comment, not a threaded reply).",
+      "files": [],
+      "assertions": [
+        "Lists review comments using `gh api repos/{owner}/{repo}/pulls/15/comments`",
+        "Identifies the correct comment by filtering on path (src/auth.ts) and line (42)",
+        "Replies using the review comment replies endpoint (`/comments/<id>/replies`)",
+        "Does NOT use `gh pr comment` (that would create a top-level timeline comment, not a threaded reply)",
+        "Includes the AI attribution header in the reply body",
+        "The reply explains the Node 12 compatibility reason as requested"
+      ]
+    },
+    {
+      "id": 9,
+      "prompt": "Can you go through all the review comments on PR #22 and summarize what the reviewers are asking for? Then help me respond to each one.",
+      "expected_output": "The agent should: 1) List all review comments via `gh api`, 2) Group them by thread (using in_reply_to_id), 3) Present a summary of each thread to the user, 4) Draft replies and get confirmation before posting.",
+      "files": [],
+      "assertions": [
+        "Lists all review comments using `gh api repos/{owner}/{repo}/pulls/22/comments`",
+        "Groups or filters comments to identify distinct threads (using in_reply_to_id)",
+        "Presents a clear summary of each review thread to the user",
+        "Drafts reply content for the user to review before posting",
+        "Does NOT post replies without user confirmation",
+        "Uses the correct reply endpoint for each comment when posting"
+      ]
+    },
+    {
+      "id": 10,
+      "prompt": "We need to publish a new release. Tag it as v2.1.0, auto-generate the release notes from the commits, and upload the build artifact from ./dist/app.tar.gz.",
+      "expected_output": "The agent should use `gh release create v2.1.0 --generate-notes ./dist/app.tar.gz` to create the release with auto-generated notes and the asset in one command.",
+      "files": [],
+      "assertions": [
+        "Uses `gh release create` with the tag `v2.1.0`",
+        "Uses `--generate-notes` to auto-generate release notes",
+        "Includes `./dist/app.tar.gz` as an asset in the create command",
+        "Does NOT use `glab release` or curl",
+        "Asks for confirmation before creating the release (Tier 3 safety -- creates content)"
+      ]
+    },
+    {
+      "id": 11,
+      "prompt": "I need to find all open issues labeled 'bug' across our organization's repos. Can you search for them?",
+      "expected_output": "The agent should use `gh search issues` with appropriate filters for label and state, scoped to the organization.",
+      "files": [],
+      "assertions": [
+        "Uses `gh search issues` (not `gh issue list` which is repo-scoped)",
+        "Filters by label 'bug' using `--label bug` or search syntax",
+        "Filters for open state using `--state open` or search syntax",
+        "Scopes to the organization using `--owner <org>` or search syntax",
+        "Presents results clearly to the user"
+      ]
+    },
+    {
+      "id": 12,
+      "prompt": "Can you use the GitHub API to get a list of all PR review comments grouped by file, along with the commenter's username? Use the --jq flag to filter the output.",
+      "expected_output": "The agent should use `gh api repos/{owner}/{repo}/pulls/<number>/comments --jq '...'` with a jq expression that groups by path and extracts usernames. It should use the native --jq flag, not pipe to external jq.",
+      "files": [],
+      "assertions": [
+        "Uses `gh api` with the pulls comments endpoint",
+        "Uses the native `--jq` flag (not piping to external `jq`)",
+        "The jq expression groups or organizes by file path",
+        "The jq expression includes the commenter's username (.user.login)",
+        "Does NOT use `glab api` or other non-GitHub tooling"
+      ]
+    }
+  ]
+}

--- a/skills/system/gh/references/api-patterns.md
+++ b/skills/system/gh/references/api-patterns.md
@@ -1,0 +1,319 @@
+# gh API Patterns Reference
+
+This file covers common `gh api` patterns for operations that go beyond the built-in subcommands.
+
+## Table of Contents
+
+1. [Authentication and basics](#authentication-and-basics)
+2. [Repository information](#repository-information)
+3. [Issues (advanced)](#issues-advanced)
+4. [Pull requests (advanced)](#pull-requests-advanced)
+5. [Review comments and threads](#review-comments-and-threads)
+6. [Users and teams](#users-and-teams)
+7. [Labels and milestones](#labels-and-milestones)
+8. [GraphQL queries](#graphql-queries)
+
+---
+
+## Authentication and basics
+
+`gh api` inherits authentication from `gh auth`. When inside a git repo, it auto-detects the GitHub instance and repository.
+
+```bash
+# Test connectivity
+gh api repos/{owner}/{repo}
+
+# Get current user
+gh api user --jq '.login'
+```
+
+### HTTP methods
+
+```bash
+gh api PATH                              # GET (default)
+gh api -X POST PATH -f key=value         # POST with string fields
+gh api -X PATCH PATH -f key=value        # PATCH
+gh api -X PUT PATH -f key=value          # PUT
+gh api -X DELETE PATH                    # DELETE
+```
+
+### Passing data
+
+- `-f key=value` -- string field (always treated as a string)
+- `-F key=value` -- typed field (numbers, booleans without quotes; `true`, `false`, `null`, integers auto-convert)
+- `-F key=@file.json` -- read value from file
+- `--input file.json` -- send file as the entire request body
+
+### Pagination
+
+```bash
+# Auto-paginate all results
+gh api repos/{owner}/{repo}/issues --paginate
+
+# Paginate and collect into a single JSON array
+gh api repos/{owner}/{repo}/issues --paginate --slurp
+
+# Manual pagination
+gh api "repos/{owner}/{repo}/issues?per_page=100&page=2"
+```
+
+### The `--jq` flag
+
+`gh api` has native `--jq` support -- no need to pipe to external `jq`:
+
+```bash
+# Extract a single field
+gh api user --jq '.login'
+
+# Filter arrays
+gh api repos/{owner}/{repo}/issues --jq '.[] | select(.labels | length > 0) | {number, title}'
+
+# Tabular output
+gh api repos/{owner}/{repo}/contributors --jq '.[] | [.login, .contributions] | @tsv'
+
+# Combine with --paginate
+gh api repos/{owner}/{repo}/issues --paginate --jq '.[].title'
+```
+
+---
+
+## Repository information
+
+```bash
+# Get repository details
+gh api repos/{owner}/{repo}
+
+# Get default branch
+gh api repos/{owner}/{repo} --jq '.default_branch'
+
+# List collaborators
+gh api repos/{owner}/{repo}/collaborators --jq '.[] | {login: .login, role: .role_name}'
+
+# Get branch protection rules
+gh api repos/{owner}/{repo}/branches/main/protection
+
+# List repository topics
+gh api repos/{owner}/{repo}/topics --jq '.names'
+
+# List webhooks
+gh api repos/{owner}/{repo}/hooks
+```
+
+---
+
+## Issues (advanced)
+
+```bash
+# Get issue details with full metadata
+gh api repos/{owner}/{repo}/issues/42
+
+# List issue comments (timeline comments)
+gh api repos/{owner}/{repo}/issues/42/comments
+
+# Add a comment with formatting
+gh api -X POST repos/{owner}/{repo}/issues/42/comments \
+  -f body="## Summary\nThe fix has been deployed to staging."
+
+# List issue events (label changes, assignments, etc.)
+gh api repos/{owner}/{repo}/issues/42/events
+
+# List issue timeline (comprehensive event history)
+gh api repos/{owner}/{repo}/issues/42/timeline
+
+# Lock an issue conversation
+gh api -X PUT repos/{owner}/{repo}/issues/42/lock \
+  -f lock_reason="resolved"
+
+# Set issue as discussion (convert)
+gh api -X PATCH repos/{owner}/{repo}/issues/42 \
+  -f state="closed" -f state_reason="not_planned"
+```
+
+---
+
+## Pull requests (advanced)
+
+```bash
+# Get PR details with full metadata
+gh api repos/{owner}/{repo}/pulls/15
+
+# List PR files (changed files summary)
+gh api repos/{owner}/{repo}/pulls/15/files --jq '.[] | {filename, status, additions, deletions}'
+
+# List commits in a PR
+gh api repos/{owner}/{repo}/pulls/15/commits --jq '.[] | {sha: .sha[0:7], message: .commit.message}'
+
+# Check merge status and conflicts
+gh api repos/{owner}/{repo}/pulls/15 --jq '{mergeable, mergeable_state, merge_commit_sha}'
+
+# List PR reviews
+gh api repos/{owner}/{repo}/pulls/15/reviews --jq '.[] | {id, user: .user.login, state, body}'
+
+# Get a specific review's comments
+gh api repos/{owner}/{repo}/pulls/15/reviews/<review_id>/comments
+
+# List requested reviewers
+gh api repos/{owner}/{repo}/pulls/15/requested_reviewers --jq '{users: [.users[].login], teams: [.teams[].slug]}'
+
+# List PR pipelines / check runs
+gh api repos/{owner}/{repo}/commits/<sha>/check-runs --jq '.check_runs[] | {name, status, conclusion}'
+```
+
+---
+
+## Review comments and threads
+
+This is the most common reason to use `gh api` for PRs -- the CLI has no subcommands for inline code comments.
+
+```bash
+# List all review comments on a PR
+gh api repos/{owner}/{repo}/pulls/15/comments \
+  --jq '.[] | {id, in_reply_to_id, user: .user.login, path, line, body: (.body | .[0:80])}'
+
+# Reply to a review comment (by comment ID)
+gh api -X POST repos/{owner}/{repo}/pulls/15/comments/<comment_id>/replies \
+  -f body="Good point -- I'll fix this."
+
+# Alternative: reply using in_reply_to parameter
+gh api -X POST repos/{owner}/{repo}/pulls/15/comments \
+  -f body="Agreed." \
+  -F in_reply_to=<comment_id>
+
+# Create a new inline comment on a specific line
+COMMIT_SHA=$(gh pr view 15 --json headRefOid --jq '.headRefOid')
+gh api -X POST repos/{owner}/{repo}/pulls/15/comments \
+  -f body="Consider adding error handling here." \
+  -f commit_id="$COMMIT_SHA" \
+  -f path="src/auth.ts" \
+  -F line=42 \
+  -f side="RIGHT"
+
+# Create a multi-line review comment
+gh api -X POST repos/{owner}/{repo}/pulls/15/comments \
+  -f body="This whole block should be extracted into a helper." \
+  -f commit_id="$COMMIT_SHA" \
+  -f path="src/auth.ts" \
+  -F start_line=30 \
+  -f start_side="RIGHT" \
+  -F line=45 \
+  -f side="RIGHT"
+
+# Edit a review comment
+gh api -X PATCH repos/{owner}/{repo}/pulls/comments/<comment_id> \
+  -f body="Updated comment text."
+
+# Delete a review comment
+gh api -X DELETE repos/{owner}/{repo}/pulls/comments/<comment_id>
+
+# Edit a PR timeline comment (issue-style comment)
+gh api -X PATCH repos/{owner}/{repo}/issues/comments/<comment_id> \
+  -f body="Updated timeline comment."
+```
+
+---
+
+## Users and teams
+
+```bash
+# Search for a user by username
+gh api "users/jdoe"
+
+# List organization members
+gh api orgs/<org>/members --jq '.[] | .login'
+
+# List team members
+gh api orgs/<org>/teams/<team-slug>/members --jq '.[] | .login'
+
+# Check if user is a collaborator
+gh api repos/{owner}/{repo}/collaborators/<username> --silent && echo "yes" || echo "no"
+```
+
+---
+
+## Labels and milestones
+
+```bash
+# List all labels (with colors and descriptions)
+gh api repos/{owner}/{repo}/labels --jq '.[] | {name, color, description}'
+
+# Create a label
+gh api -X POST repos/{owner}/{repo}/labels \
+  -f name="priority:critical" \
+  -f color="FF0000" \
+  -f description="Critical priority issue"
+
+# List milestones
+gh api repos/{owner}/{repo}/milestones --jq '.[] | {number, title, state, due_on}'
+
+# Get issues in a milestone
+gh api "repos/{owner}/{repo}/issues?milestone=3&state=all" --jq '.[] | {number, title, state}'
+```
+
+---
+
+## GraphQL queries
+
+For complex queries that need data from multiple resources at once, use GraphQL:
+
+```bash
+# Basic GraphQL query
+gh api graphql -f query='
+  query {
+    repository(owner: "myorg", name: "myrepo") {
+      name
+      description
+      pullRequests(states: OPEN, first: 10) {
+        nodes {
+          number
+          title
+          author { login }
+          reviewDecision
+          commits(last: 1) {
+            nodes {
+              commit {
+                statusCheckRollup {
+                  state
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+'
+
+# GraphQL with variables
+gh api graphql -f query='
+  query($owner: String!, $name: String!, $search: String!) {
+    repository(owner: $owner, name: $name) {
+      issues(filterBy: {states: OPEN}, first: 20, orderBy: {field: UPDATED_AT, direction: DESC}) {
+        nodes {
+          number
+          title
+          labels(first: 5) { nodes { name } }
+        }
+      }
+    }
+  }
+' -f owner="myorg" -f name="myrepo" -f search="login"
+```
+
+### Paginated GraphQL
+
+Use `$endCursor` with `--paginate` for automatic pagination:
+
+```bash
+gh api graphql --paginate -f query='
+  query($endCursor: String) {
+    repository(owner: "myorg", name: "myrepo") {
+      issues(first: 100, after: $endCursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes { number title }
+      }
+    }
+  }
+'
+```
+
+The `--paginate` flag with `$endCursor` automatically fetches all pages. Add `--slurp` to merge all pages into a single JSON array.

--- a/skills/system/glab/SKILL.md
+++ b/skills/system/glab/SKILL.md
@@ -117,12 +117,16 @@ GITLAB_HOST=<hostname> glab api user | jq -r '.username'
 
 > **Note:** `glab api` does not support `--jq` (that's a `gh` feature). Always pipe to `jq` instead.
 
-**Example** — creating an MR:
+Before writing any content, **always fetch the username first** and embed it in the header. Do not hardcode a username or leave the placeholder unfilled:
 
 ```bash
+# Step 1: fetch the username (do this once per session)
+GL_USERNAME=$(GITLAB_HOST=<hostname> glab api user | jq -r '.username')
+
+# Step 2: use it in the content
 GITLAB_HOST=gitlab.example.com glab mr create \
   --title "feat: add dark mode" \
-  --description "🤖 *This was written by an AI agent on behalf of @alice.*
+  --description "🤖 *This was written by an AI agent on behalf of @${GL_USERNAME}.*
 
 ---
 
@@ -137,7 +141,7 @@ GITLAB_HOST=gitlab.example.com glab mr create \
 ```bash
 GITLAB_HOST=gitlab.example.com glab issue note 42 \
   -R group/project \
-  --message "🤖 *This was written by an AI agent on behalf of @alice.*
+  --message "🤖 *This was written by an AI agent on behalf of @${GL_USERNAME}.*
 
 ---
 


### PR DESCRIPTION
> *This was written by an AI agent on behalf of @paolomainardi.*

---

## Summary

- Adds a new `gh` CLI skill at `skills/system/gh/` -- the GitHub counterpart to the existing `glab` skill
- Covers issues, pull requests, GitHub Actions, releases, search, and `gh api` patterns
- Includes a dedicated **PR Comments and Reviews** section for replying to inline review comments via `gh api` (no CLI subcommand exists for this)
- Three-tier safety protocol covering `gh`-specific risks (`--admin` merge bypass, secrets/variables, workflow disable)
- AI attribution header policy for all agent-created content
- API patterns reference (`references/api-patterns.md`) with `--jq` filtering, GraphQL, pagination, and review comment management
- 12 eval scenarios covering issue/PR creation, CI monitoring, review comment replies, releases, search, and URL handling
- All commands validated against `gh` v2.88.1 -- corrects several inaccuracies found in the community `gh-cli` skill (e.g., `--edit-last` vs `--edit <id>`, `--label` vs `--labels`, non-existent `--dismiss` flag)

## Files

| File | Lines | Purpose |
|------|-------|---------|
| `skills/system/gh/SKILL.md` | ~430 | Main skill definition |
| `skills/system/gh/references/api-patterns.md` | ~240 | gh api patterns reference |
| `skills/system/gh/evals/evals.json` | ~190 | 12 evaluation scenarios |
| `SYSTEM.md` | +1 | Added gh to available skills |
| `CHANGELOG.md` | +12 | Added [2026-03-20] entry |

## Key design decisions

- **No GHES support** (github.com only) -- keeps the skill focused; can be added later
- **No Codespaces** -- deferred to a follow-up
- **Secrets/variables in Tier 2** (explicit request only), not Tier 1 (forbidden)
- **Review comment replies** documented thoroughly since this is where agents most commonly get it wrong (posting top-level comments instead of threaded replies)