### PR TITLE
fix: use blockquote format for AI attribution header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Changes are grouped by date.
 
 ## [Unreleased]
 
+## [2026-03-21]
+
+### Fixed
+
+- `gh`, `glab` skills: AI attribution header now uses blockquote format (`) instead of bare text with `---` separator -- fixes double-separator rendering issues and provides consistent visual distinction on both GitHub and GitLab
+
 ## [2026-03-20]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changes are grouped by date.
 ### Fixed
 
 - `gh`, `glab` skills: AI attribution header now uses blockquote format (`) instead of bare text with `---` separator -- fixes double-separator rendering issues and provides consistent visual distinction on both GitHub and GitLab
+- `gh`, `glab` skills: added heredoc warning about single-quoted delimiters suppressing variable expansion in attribution header
 
 ## [2026-03-20]
 

--- a/skills/system/gh/SKILL.md
+++ b/skills/system/gh/SKILL.md
@@ -76,9 +76,7 @@ Issues and PRs both use `#` prefix.
 Whenever you create or post content on GitHub on behalf of the user -- including **PR descriptions** (`gh pr create`), **issue descriptions** (`gh issue create`), **comments** (`gh pr comment`, `gh issue comment`), **reviews** (`gh pr review`), or **`gh api` body fields** -- you **must** prepend the following header to make it clear the content was authored by an AI agent acting on behalf of the user:
 
 ```
-🤖 *This was written by an AI agent on behalf of @<username>.*
-
----
+> :robot: _This was written by an AI agent on behalf of @<username>._
 ```
 
 Before writing any content, **always fetch the username first** and embed it in the header. Do not hardcode a username or leave the placeholder unfilled:
@@ -90,9 +88,7 @@ GH_USERNAME=$(gh api user --jq '.login')
 # Step 2: use it in the content
 gh pr create \
   --title "feat: add dark mode" \
-  --body "🤖 *This was written by an AI agent on behalf of @${GH_USERNAME}.*
-
----
+  --body "> :robot: _This was written by an AI agent on behalf of @${GH_USERNAME}._
 
 ## Summary
 
@@ -104,9 +100,7 @@ gh pr create \
 
 ```bash
 gh issue comment 42 \
-  --body "🤖 *This was written by an AI agent on behalf of @${GH_USERNAME}.*
-
----
+  --body "> :robot: _This was written by an AI agent on behalf of @${GH_USERNAME}._
 
 ## Triage
 
@@ -258,9 +252,7 @@ Use the dedicated replies endpoint:
 
 ```bash
 gh api -X POST repos/{owner}/{repo}/pulls/15/comments/<comment_id>/replies \
-  -f body="🤖 *This was written by an AI agent on behalf of @${GH_USERNAME}.*
-
----
+  -f body="> :robot: _This was written by an AI agent on behalf of @${GH_USERNAME}._
 
 The null check is needed because..."
 ```

--- a/skills/system/gh/SKILL.md
+++ b/skills/system/gh/SKILL.md
@@ -109,6 +109,19 @@ Root cause identified: ..."
 
 This applies to **every** piece of content the agent creates, regardless of length or context. Never skip the header.
 
+> **Heredoc warning:** when using `cat <<EOF` to build the body, **never** single-quote the delimiter (`<<'EOF'`). Single-quoted heredocs suppress variable expansion and produce the literal string `$GH_USERNAME` instead of the resolved value. Always use an unquoted delimiter:
+>
+> ```bash
+> gh pr create --title "feat: add dark mode" --body "$(cat <<EOF
+> > :robot: _This was written by an AI agent on behalf of @${GH_USERNAME}._
+>
+> ## Summary
+>
+> - Adds dark mode toggle to settings page
+> EOF
+> )"
+> ```
+
 ---
 
 ## Issues

--- a/skills/system/glab/SKILL.md
+++ b/skills/system/glab/SKILL.md
@@ -104,9 +104,7 @@ Issues use `#`, merge requests use `!`.
 Whenever you create or post content on GitLab on behalf of the user — including **MR descriptions** (`glab mr create`), **issue descriptions** (`glab issue create`), **comments/notes** (`glab issue note`, `glab mr note`), or **`glab api` body fields** — you **must** prepend the following header to make it clear the content was authored by an AI agent acting on behalf of the user:
 
 ```
-🤖 *This was written by an AI agent on behalf of @<username>.*
-
----
+> :robot: _This was written by an AI agent on behalf of @<username>._
 ```
 
 To get the current authenticated username run:
@@ -126,9 +124,7 @@ GL_USERNAME=$(GITLAB_HOST=<hostname> glab api user | jq -r '.username')
 # Step 2: use it in the content
 GITLAB_HOST=gitlab.example.com glab mr create \
   --title "feat: add dark mode" \
-  --description "🤖 *This was written by an AI agent on behalf of @${GL_USERNAME}.*
-
----
+  --description "> :robot: _This was written by an AI agent on behalf of @${GL_USERNAME}._
 
 ## Summary
 
@@ -141,9 +137,7 @@ GITLAB_HOST=gitlab.example.com glab mr create \
 ```bash
 GITLAB_HOST=gitlab.example.com glab issue note 42 \
   -R group/project \
-  --message "🤖 *This was written by an AI agent on behalf of @${GL_USERNAME}.*
-
----
+  --message "> :robot: _This was written by an AI agent on behalf of @${GL_USERNAME}._
 
 ## Triage
 

--- a/skills/system/glab/SKILL.md
+++ b/skills/system/glab/SKILL.md
@@ -146,6 +146,19 @@ Root cause identified: ..."
 
 This applies to **every** piece of content the agent creates, regardless of length or context. Never skip the header.
 
+> **Heredoc warning:** when using `cat <<EOF` to build the body, **never** single-quote the delimiter (`<<'EOF'`). Single-quoted heredocs suppress variable expansion and produce the literal string `$GL_USERNAME` instead of the resolved value. Always use an unquoted delimiter:
+>
+> ```bash
+> glab mr create --title "feat: add dark mode" --description "$(cat <<EOF
+> > :robot: _This was written by an AI agent on behalf of @${GL_USERNAME}._
+>
+> ## Summary
+>
+> - Adds dark mode toggle to settings page
+> EOF
+> )"
+> ```
+
 ---
 
 ## Issues


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## Summary

- Replaces bare `🤖 *text*` + `---` separator with blockquote format (`> :robot: _text_`) in both `gh` and `glab` skills
- Fixes double-separator rendering issue on GitHub PRs where `---` from the attribution and `---` from body content would stack
- Uses `:robot:` shortcode and `_underscore_` italics for consistent rendering across GitHub and GitLab

## Before / After

**Before** (bare text + separator):
```
🤖 *This was written by an AI agent on behalf of @user.*

---
```

**After** (blockquote, no separator needed):
```
> :robot: _This was written by an AI agent on behalf of @user._
```

The blockquote renders as a visually distinct indented block with a left border, making the attribution self-contained without needing a `---` separator.


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Replace bare emoji + italic text + `---` separator with blockquote format

- Fixes double-separator rendering on GitHub/GitLab PRs

- Updates `gh` and `glab` skill docs with new attribution header format

- Adds changelog entry for the fix


___

### Diagram Walkthrough


```mermaid
flowchart LR
  old["🤖 *text*\n\n---"]
  new["> :robot: _text_"]
  old -- "replaced with" --> new
  gh["gh SKILL.md"] -- "updated" --> new
  glab["glab SKILL.md"] -- "updated" --> new
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Add changelog entry for attribution header fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Adds a new <code>[2026-03-21]</code> changelog entry under <code>[Unreleased]</code><br> <li> Documents the fix for AI attribution header in <code>gh</code> and <code>glab</code> skills</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sf-awesome-copilot/pull/18/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SKILL.md</strong><dd><code>Update gh skill AI attribution to blockquote format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

skills/system/gh/SKILL.md

<ul><li>Replaces bare <code>🤖 *text*</code> + <code>---</code> separator with <code>> :robot: _text_</code> <br>blockquote format<br> <li> Updates all three example code blocks (PR create, issue comment, API <br>reply) with new format<br> <li> Removes the extra blank line and <code>---</code> separator after the attribution <br>header</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sf-awesome-copilot/pull/18/files#diff-52d530ca4efb47a9e9d352ac179a3dd74b8436c2c82e5eac754e35558ff2eccc">+4/-12</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SKILL.md</strong><dd><code>Update glab skill AI attribution to blockquote format</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

skills/system/glab/SKILL.md

<ul><li>Replaces bare <code>🤖 *text*</code> + <code>---</code> separator with <code>> :robot: _text_</code> <br>blockquote format<br> <li> Updates both example code blocks (MR create, issue note) with new <br>format<br> <li> Removes the extra blank line and <code>---</code> separator after the attribution <br>header</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sf-awesome-copilot/pull/18/files#diff-84e2a4ece59b87af4b97b9aaa6ccd64e9f4abf7cc3e00eae3678e44f42740023">+3/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

