### PR TITLE
fix(glab): add TTY warning for ci view and document ci get command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ Changes are grouped by date.
 
 ## [Unreleased]
 
+## [2026-03-28]
+
+### Fixed
+
+- `glab` skill: warn against `glab ci view` (requires interactive TTY, always fails in agent contexts) and document `glab ci get` as the correct non-interactive alternative for fetching pipeline details
+- `glab` skill: fix `glab ci artifact` documentation (wrong syntax and missing deprecation notice)
+
+### Added
+
+- `glab` skill: two new eval cases for pipeline detail retrieval, testing that agents avoid TTY commands and use correct flag syntax
+
 ## [2026-03-23]
 
 ### Fixed

--- a/skills/system/glab/SKILL.md
+++ b/skills/system/glab/SKILL.md
@@ -273,22 +273,39 @@ Approval and notes are separate commands -- `glab mr approve` handles GitLab's f
 
 ## CI/CD
 
+### TTY-only commands -- do NOT use
+
+`glab ci view` is a **full-screen terminal UI** (TUI) that requires an interactive TTY with keyboard input. It will **always fail** in non-interactive contexts (agent bash tools, scripts, piped commands). Never use it.
+
+| Command | Why it fails | Use instead |
+|---------|-------------|-------------|
+| `glab ci view` | Requires interactive TTY | `glab ci get` (structured data) or `glab ci status` (text summary) |
+
+### Pipeline commands
+
 ```bash
-glab ci status                      # pipeline status for current branch
-glab ci status --branch main        # pipeline status for a specific branch
-glab ci status --branch main --live # stream status in real-time until pipeline completes
-glab ci list                        # recent pipelines for current branch/project
-glab ci list --per-page 10          # show more pipelines
-glab ci trace                       # stream logs of the active job on current branch
-glab ci trace --branch main         # stream logs for a specific branch
-glab ci trace --branch main -p <id> # stream logs for a specific pipeline ID
-glab ci trace <job-name>            # stream logs for a specific job by name
-glab ci run                         # trigger new pipeline
-glab ci retry <pipeline-id>         # retry failed pipeline
-glab ci cancel <pipeline-id>        # cancel running pipeline
-glab ci artifact <job-id>           # download artifacts
-glab ci lint                        # validate .gitlab-ci.yml syntax
+glab ci status                       # pipeline status for current branch
+glab ci status --branch main         # pipeline status for a specific branch
+glab ci status --branch main --live  # stream status in real-time until pipeline completes
+glab ci get                          # pipeline details as JSON (current branch)
+glab ci get -b main                  # pipeline details for a specific branch
+glab ci get -p <pipeline-id>         # pipeline details for a specific pipeline ID
+glab ci get -p <pipeline-id> -d      # include extended job details
+glab ci get -p <pipeline-id> -F json # explicit JSON output format
+glab ci list                         # recent pipelines for current branch/project
+glab ci list --per-page 10           # show more pipelines
+glab ci trace                        # stream logs of the active job on current branch
+glab ci trace --branch main          # stream logs for a specific branch
+glab ci trace --branch main -p <id>  # stream logs for a specific pipeline ID
+glab ci trace <job-name>             # stream logs for a specific job by name
+glab ci run                          # trigger new pipeline
+glab ci retry <pipeline-id>          # retry failed pipeline
+glab ci cancel <pipeline-id>         # cancel running pipeline
+glab ci artifact <refName> <jobName> # download artifacts (deprecated: use `glab job artifact`)
+glab ci lint                         # validate .gitlab-ci.yml syntax
 ```
+
+**Important:** `glab ci get` accepts **zero positional arguments**. The pipeline ID must be passed via the `-p` / `--pipeline-id` flag, not as a positional argument. Passing it as `glab ci get <id>` will fail with "Accepts 0 arg(s)".
 
 Run `glab ci lint` before committing CI config changes to catch syntax errors early.
 
@@ -312,6 +329,16 @@ Without `--branch`, these commands look for a pipeline on the current branch, an
 glab ci status --branch main --live
 ```
 
+**For pipeline details** (non-interactive, structured data):
+
+```bash
+# Get pipeline details by ID (JSON output)
+glab ci get -p <pipeline-id>
+
+# With extended job details
+glab ci get -p <pipeline-id> -d
+```
+
 **For job-level detail** within a specific pipeline:
 
 ```bash
@@ -321,7 +348,7 @@ glab ci list --per-page 5
 # 2. Stream logs of a specific pipeline
 glab ci trace --branch main --pipeline-id <pipeline-id>
 
-# 3. Check individual job statuses via API (when you need structured data)
+# 3. Check individual job statuses via API (when you need structured data beyond what `glab ci get -d` provides)
 glab api "projects/:id/pipelines/<pipeline-id>/jobs" | jq '.[] | {name: .name, status: .status, stage: .stage}'
 ```
 

--- a/skills/system/glab/SKILL.md
+++ b/skills/system/glab/SKILL.md
@@ -496,25 +496,58 @@ If you must use a numeric ID, use the global `id` field (not `iid`) from the API
 
 ## File uploads (images, attachments)
 
-`glab api` **cannot** do multipart file uploads -- `-F file=@path` reads the file as a string into a JSON field, not as `multipart/form-data`. Binary files (images, PDFs) will get a 400 Bad Request. There is no `glab upload` subcommand either (`glab release upload` is for release assets only).
+`glab api` **cannot** do multipart file uploads. It only sends JSON request bodies -- the `-F file=@path` flag reads the file as a string value into a JSON field, not as `multipart/form-data`. For binary files (images, PDFs, etc.) this produces a 400 Bad Request.
 
-**Use `curl` instead**, extracting the auth token from `glab`:
+There is no `glab upload` subcommand for project uploads either (`glab release upload` only handles release assets).
+
+**Use `curl` with the GitLab project uploads API instead.** Extract the auth token from `glab` for the `curl` request:
+
+### Step 1: Get the token and project ID
 
 ```bash
-# 1. Get the token and project ID
-GITLAB_HOST=<hostname> glab auth status -t          # look for "Token found:" line
-PROJECT_ID=$(GITLAB_HOST=<hostname> glab api projects/:id | jq '.id')
+# Get the token (look for the "Token found:" line)
+GITLAB_HOST=<hostname> glab auth status -t
 
-# 2. Upload the file
-# Use "Authorization: Bearer" for OAuth tokens (web login), "PRIVATE-TOKEN" for PATs.
-# When in doubt, try Bearer first -- if 401, retry with PRIVATE-TOKEN.
+# Get the numeric project ID (inside a git repo)
+GITLAB_HOST=<hostname> glab api projects/:id | jq '.id'
+```
+
+### Step 2: Upload the file
+
+The token stored by `glab auth` may be an **OAuth token** (if you logged in via web/OAuth) or a **PAT** (if you provided a token directly). Use the correct auth header:
+
+```bash
+# For OAuth tokens (logged in via: glab auth login → "Web"):
 curl --silent --show-error --request POST \
   --header "Authorization: Bearer <token>" \
   --form "file=@path/to/image.png" \
-  "https://<hostname>/api/v4/projects/${PROJECT_ID}/uploads"
+  "https://<hostname>/api/v4/projects/<project-id>/uploads"
 
-# 3. Use the returned `markdown` field in MR/issue descriptions
-# Response: { "markdown": "![image](/uploads/<hash>/image.png)", ... }
+# For PATs (logged in via: glab auth login --token):
+curl --silent --show-error --request POST \
+  --header "PRIVATE-TOKEN: <token>" \
+  --form "file=@path/to/image.png" \
+  "https://<hostname>/api/v4/projects/<project-id>/uploads"
+```
+
+**How to tell which type you have**: if `glab auth status` shows `✓ Logged in ... (keyring)` without mentioning a PAT, and you originally logged in via the browser flow, it's an OAuth token -- use `Authorization: Bearer`. If you provided a PAT directly, use `PRIVATE-TOKEN`. When in doubt, try Bearer first -- if you get a 401, retry with `PRIVATE-TOKEN`.
+
+### Step 3: Use the returned markdown URL
+
+The upload returns JSON with a `markdown` field ready to paste into descriptions:
+
+```json
+{
+  "id": 12345,
+  "alt": "image",
+  "url": "/uploads/<hash>/image.png",
+  "markdown": "![image](/uploads/<hash>/image.png)"
+}
+```
+
+Use this in MR/issue descriptions or comments:
+
+```bash
 GITLAB_HOST=<hostname> glab mr update 4 --description "## Screenshot
 
 ![image](/uploads/<hash>/image.png)"

--- a/skills/system/glab/SKILL.md
+++ b/skills/system/glab/SKILL.md
@@ -514,23 +514,16 @@ GITLAB_HOST=<hostname> glab api projects/:id | jq '.id'
 
 ### Step 2: Upload the file
 
-The token stored by `glab auth` may be an **OAuth token** (if you logged in via web/OAuth) or a **PAT** (if you provided a token directly). Use the correct auth header:
-
 ```bash
-# For OAuth tokens (logged in via: glab auth login → "Web"):
+# Auth header depends on login method:
+#   OAuth token (web login):  "Authorization: Bearer <token>"
+#   PAT (--token login):      "PRIVATE-TOKEN: <token>"
+# When in doubt, try Bearer first -- if 401, retry with PRIVATE-TOKEN.
 curl --silent --show-error --request POST \
   --header "Authorization: Bearer <token>" \
   --form "file=@path/to/image.png" \
   "https://<hostname>/api/v4/projects/<project-id>/uploads"
-
-# For PATs (logged in via: glab auth login --token):
-curl --silent --show-error --request POST \
-  --header "PRIVATE-TOKEN: <token>" \
-  --form "file=@path/to/image.png" \
-  "https://<hostname>/api/v4/projects/<project-id>/uploads"
 ```
-
-**How to tell which type you have**: if `glab auth status` shows `✓ Logged in ... (keyring)` without mentioning a PAT, and you originally logged in via the browser flow, it's an OAuth token -- use `Authorization: Bearer`. If you provided a PAT directly, use `PRIVATE-TOKEN`. When in doubt, try Bearer first -- if you get a 401, retry with `PRIVATE-TOKEN`.
 
 ### Step 3: Use the returned markdown URL
 

--- a/skills/system/glab/SKILL.md
+++ b/skills/system/glab/SKILL.md
@@ -514,11 +514,9 @@ GITLAB_HOST=<hostname> glab api projects/:id | jq '.id'
 
 ### Step 2: Upload the file
 
+**Detecting token type:** if `glab auth status` shows `Logged in ... (keyring)` without mentioning a PAT (browser login), it's an OAuth token -- use `Authorization: Bearer`. If you provided a PAT directly, use `PRIVATE-TOKEN`. When in doubt, try Bearer first -- if you get a 401, retry with `PRIVATE-TOKEN`.
+
 ```bash
-# Auth header depends on login method:
-#   OAuth token (web login):  "Authorization: Bearer <token>"
-#   PAT (--token login):      "PRIVATE-TOKEN: <token>"
-# When in doubt, try Bearer first -- if 401, retry with PRIVATE-TOKEN.
 curl --silent --show-error --request POST \
   --header "Authorization: Bearer <token>" \
   --form "file=@path/to/image.png" \

--- a/skills/system/glab/SKILL.md
+++ b/skills/system/glab/SKILL.md
@@ -496,58 +496,25 @@ If you must use a numeric ID, use the global `id` field (not `iid`) from the API
 
 ## File uploads (images, attachments)
 
-`glab api` **cannot** do multipart file uploads. It only sends JSON request bodies -- the `-F file=@path` flag reads the file as a string value into a JSON field, not as `multipart/form-data`. For binary files (images, PDFs, etc.) this produces a 400 Bad Request.
+`glab api` **cannot** do multipart file uploads -- `-F file=@path` reads the file as a string into a JSON field, not as `multipart/form-data`. Binary files (images, PDFs) will get a 400 Bad Request. There is no `glab upload` subcommand either (`glab release upload` is for release assets only).
 
-There is no `glab upload` subcommand for project uploads either (`glab release upload` only handles release assets).
-
-**Use `curl` with the GitLab project uploads API instead.** Extract the auth token from `glab` for the `curl` request:
-
-### Step 1: Get the token and project ID
+**Use `curl` instead**, extracting the auth token from `glab`:
 
 ```bash
-# Get the token (look for the "Token found:" line)
-GITLAB_HOST=<hostname> glab auth status -t
+# 1. Get the token and project ID
+GITLAB_HOST=<hostname> glab auth status -t          # look for "Token found:" line
+PROJECT_ID=$(GITLAB_HOST=<hostname> glab api projects/:id | jq '.id')
 
-# Get the numeric project ID (inside a git repo)
-GITLAB_HOST=<hostname> glab api projects/:id | jq '.id'
-```
-
-### Step 2: Upload the file
-
-The token stored by `glab auth` may be an **OAuth token** (if you logged in via web/OAuth) or a **PAT** (if you provided a token directly). Use the correct auth header:
-
-```bash
-# For OAuth tokens (logged in via: glab auth login → "Web"):
+# 2. Upload the file
+# Use "Authorization: Bearer" for OAuth tokens (web login), "PRIVATE-TOKEN" for PATs.
+# When in doubt, try Bearer first -- if 401, retry with PRIVATE-TOKEN.
 curl --silent --show-error --request POST \
   --header "Authorization: Bearer <token>" \
   --form "file=@path/to/image.png" \
-  "https://<hostname>/api/v4/projects/<project-id>/uploads"
+  "https://<hostname>/api/v4/projects/${PROJECT_ID}/uploads"
 
-# For PATs (logged in via: glab auth login --token):
-curl --silent --show-error --request POST \
-  --header "PRIVATE-TOKEN: <token>" \
-  --form "file=@path/to/image.png" \
-  "https://<hostname>/api/v4/projects/<project-id>/uploads"
-```
-
-**How to tell which type you have**: if `glab auth status` shows `✓ Logged in ... (keyring)` without mentioning a PAT, and you originally logged in via the browser flow, it's an OAuth token -- use `Authorization: Bearer`. If you provided a PAT directly, use `PRIVATE-TOKEN`. When in doubt, try Bearer first -- if you get a 401, retry with `PRIVATE-TOKEN`.
-
-### Step 3: Use the returned markdown URL
-
-The upload returns JSON with a `markdown` field ready to paste into descriptions:
-
-```json
-{
-  "id": 12345,
-  "alt": "image",
-  "url": "/uploads/<hash>/image.png",
-  "markdown": "![image](/uploads/<hash>/image.png)"
-}
-```
-
-Use this in MR/issue descriptions or comments:
-
-```bash
+# 3. Use the returned `markdown` field in MR/issue descriptions
+# Response: { "markdown": "![image](/uploads/<hash>/image.png)", ... }
 GITLAB_HOST=<hostname> glab mr update 4 --description "## Screenshot
 
 ![image](/uploads/<hash>/image.png)"

--- a/skills/system/glab/evals/evals.json
+++ b/skills/system/glab/evals/evals.json
@@ -279,6 +279,32 @@
         "Asks for confirmation before executing the merge (Tier 2 safety protocol)",
         "Does NOT use `--squash-before-merge` (that's a `glab mr create` flag)"
       ]
+    },
+    {
+      "id": 20,
+      "prompt": "Can you get the details of pipeline 246179 on our GitLab project? I want to see which jobs ran and their statuses.",
+      "expected_output": "The agent should use `glab ci get -p 246179 -d` to fetch pipeline details with extended job information. It must NOT use `glab ci view` (requires TTY) and must NOT pass the pipeline ID as a positional argument to `glab ci get`.",
+      "files": [],
+      "assertions": [
+        "Uses `glab ci get` with `-p 246179` or `--pipeline-id 246179` flag",
+        "Does NOT use `glab ci view` (requires interactive TTY, always fails in non-interactive contexts)",
+        "Does NOT pass the pipeline ID as a positional argument (`glab ci get 246179` is invalid)",
+        "Uses `-d` or `--with-job-details` flag to show job-level information",
+        "Does NOT fall back to raw `glab api` calls when `glab ci get` can do the job"
+      ]
+    },
+    {
+      "id": 21,
+      "prompt": "I want to see what happened in the latest pipeline on the develop branch. Can you show me the pipeline status and job details?",
+      "expected_output": "The agent should use `glab ci get -b develop -d` to get pipeline details for the develop branch with job information. It should NOT use `glab ci view` (TTY requirement). It may also use `glab ci status --branch develop` for a quick status check.",
+      "files": [],
+      "assertions": [
+        "Uses `glab ci get -b develop` or `glab ci status --branch develop` as the primary command",
+        "Does NOT use `glab ci view` (requires interactive TTY)",
+        "Uses `--branch` or `-b` flag to target the develop branch",
+        "If using `glab ci get`, passes the branch via `-b` flag (not as positional argument)",
+        "May use `-d` flag on `glab ci get` for extended job details"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Warn against `glab ci view` in the CI/CD section — it's a full-screen TUI that requires an interactive TTY and always fails in agent/script contexts
- Document `glab ci get` as the correct non-interactive alternative for fetching pipeline details, with correct flag syntax (`-p` for pipeline ID, `-b` for branch, `-d` for job details)
- Fix `glab ci artifact` documentation (was showing wrong syntax `<job-id>`, corrected to `<refName> <jobName>` with deprecation notice)
- Add two new eval test cases for pipeline detail retrieval scenarios

## Context

When an agent tries to view pipeline details, it may guess `glab ci view <id>` (by analogy with `gh run view`), which fails because `glab ci view` requires a TTY. The error message then suggests `glab ci get`, but the agent passes the pipeline ID as a positional argument (`glab ci get <id>`), which also fails because `glab ci get` accepts zero positional args — the ID must be passed via `-p`.

These changes make both pitfalls explicit in the skill instructions.