### PR TITLE
fix(glab): document that close/reopen commands do not accept --message flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ Changes are grouped by date.
 
 ## [Unreleased]
 
+## [2026-03-29]
+
+### Fixed
+
+- `glab` skill: document that `glab mr close`, `glab issue close`, `glab mr reopen`, and `glab issue reopen` do not accept `--message` -- close/reopen with an explanation requires a separate `note` command first
+
+### Added
+
+- `glab` skill: two new eval cases for close-with-explanation scenarios (MR and issue)
+
 ## [2026-03-28]
 
 ### Fixed

--- a/skills/system/glab/SKILL.md
+++ b/skills/system/glab/SKILL.md
@@ -174,6 +174,8 @@ glab issue close 42                               # close (ask confirmation firs
 glab issue reopen 42
 ```
 
+> **Closing/reopening with a comment**: `glab issue close` and `glab issue reopen` do not accept `--message`. Add a note first: `glab issue note 42 --message "..."`, then `glab issue close 42`.
+
 ### Issue template selection
 
 Many GitLab projects define issue templates (stored in `.gitlab/issue_templates/`) that encode the team's expected structure -- sections to fill, checklists, labels via quick actions. Skipping these creates issues that don't match the project's conventions and forces manual cleanup.
@@ -264,6 +266,17 @@ glab mr rebase 15                   # rebase onto target
 glab mr update 15 --add-label "reviewed"
 glab mr close 15                    # close without merging
 ```
+
+> **`close`/`reopen` do NOT accept `--message`**: unlike `gh pr close --comment`, `glab mr close` and `glab mr reopen` only accept `--repo` -- there is no `--message` or `--comment` flag. The same applies to `glab issue close` and `glab issue reopen`. To close (or reopen) with an explanation, add a note first as a separate command:
+>
+> ```bash
+> # CORRECT -- note first, then close:
+> glab mr note 15 --message "Closing: superseded by !20."
+> glab mr close 15
+>
+> # WRONG -- fails with "Unknown flag: --message":
+> glab mr close 15 --message "Closing: superseded by !20."
+> ```
 
 **Code review workflow**: view MR -> read diff -> check CI (`glab ci status`) -> read comments -> leave feedback -> approve or request changes.
 


### PR DESCRIPTION
## Summary

- Document that `glab mr close`, `glab issue close`, `glab mr reopen`, and `glab issue reopen` do **not** accept `--message`/`-m` -- a common pitfall where agents try `glab mr close 17 --message "..."` and get "Unknown flag: --message"
- Add a prominent callout in the MR section (with CORRECT/WRONG examples) and a brief note in the Issues section, following the same blockquote pattern used for the `--squash` vs `--squash-before-merge` pitfall
- Add two new eval cases (ids 22, 23) testing that agents use `note` + `close` as two separate commands instead of `close --message`

## Context

An agent was observed failing with `glab mr close 17 --message "..."` then self-recovering by splitting into `glab mr note` + `glab mr close`. The skill should prevent this error upfront.