### PR TITLE
fix(playwright-cli): use correct npm package name @playwright/cli in npx fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Changes are grouped by date.
 
 ## [Unreleased]
 
+## [2026-03-29]
+
+### Fixed
+
+- `playwright-cli` skill: fix npx fallback to use correct package name `@playwright/cli` instead of deprecated `playwright-cli`
+
 ## [2026-03-28]
 
 ### Fixed

--- a/skills/system/playwright-cli/SKILL.md
+++ b/skills/system/playwright-cli/SKILL.md
@@ -224,11 +224,11 @@ playwright-cli kill-all
 
 ## Local installation
 
-In some cases user might want to install playwright-cli locally. If running globally available `playwright-cli` binary fails, use `npx -y playwright-cli` to run the commands. For example:
+In some cases user might want to install playwright-cli locally. If running globally available `playwright-cli` binary fails, use `npx -y @playwright/cli` to run the commands. The npm package is `@playwright/cli` (not `playwright-cli`, which is a deprecated old package). For example:
 
 ```bash
-npx -y playwright-cli open https://example.com
-npx -y playwright-cli click e1
+npx -y @playwright/cli open https://example.com
+npx -y @playwright/cli click e1
 ```
 
 ## Example: Form submission
@@ -295,16 +295,16 @@ command -v playwright-cli >/dev/null 2>&1 && echo "installed" || echo "not insta
 ```
 
 - If **installed**, use `playwright-cli` directly for all commands.
-- If **not installed**, use `npx -y playwright-cli` as a drop-in replacement for all commands. The `-y` flag skips the install confirmation prompt, which is required for non-interactive use.
+- If **not installed**, use `npx -y @playwright/cli` as a drop-in replacement for all commands. The npm package is `@playwright/cli` (not `playwright-cli`, which is a deprecated old package). The `-y` flag skips the install confirmation prompt, which is required for non-interactive use.
 
-All examples in this skill use `playwright-cli` directly. When the binary is not found, prepend `npx -y` to each command. For example:
+All examples in this skill use `playwright-cli` directly. When the binary is not found, prepend `npx -y @playwright/cli` instead of `playwright-cli` in each command. For example:
 
 ```bash
 # Binary available
 playwright-cli open https://example.com
 
-# Binary not available -- use npx -y
-npx -y playwright-cli open https://example.com
+# Binary not available -- use npx with the correct package name
+npx -y @playwright/cli open https://example.com
 ```
 
 ## Output file conventions

--- a/skills/system/playwright-cli/SKILL.md
+++ b/skills/system/playwright-cli/SKILL.md
@@ -224,7 +224,7 @@ playwright-cli kill-all
 
 ## Local installation
 
-In some cases user might want to install playwright-cli locally. If running globally available `playwright-cli` binary fails, use `npx -y @playwright/cli` to run the commands. The npm package is `@playwright/cli` (not `playwright-cli`, which is a deprecated old package). For example:
+In some cases, the user might want to install the Playwright CLI locally via the `@playwright/cli` npm package. If running globally available `playwright-cli` binary fails, use `npx -y @playwright/cli` to run the commands. The npm package is `@playwright/cli` (not `playwright-cli`, which is a deprecated old package). For example:
 
 ```bash
 npx -y @playwright/cli open https://example.com

--- a/skills/system/playwright-cli/custom-sections.md
+++ b/skills/system/playwright-cli/custom-sections.md
@@ -9,16 +9,16 @@ command -v playwright-cli >/dev/null 2>&1 && echo "installed" || echo "not insta
 ```
 
 - If **installed**, use `playwright-cli` directly for all commands.
-- If **not installed**, use `npx -y playwright-cli` as a drop-in replacement for all commands. The `-y` flag skips the install confirmation prompt, which is required for non-interactive use.
+- If **not installed**, use `npx -y @playwright/cli` as a drop-in replacement for all commands. The npm package is `@playwright/cli` (not `playwright-cli`, which is a deprecated old package). The `-y` flag skips the install confirmation prompt, which is required for non-interactive use.
 
-All examples in this skill use `playwright-cli` directly. When the binary is not found, prepend `npx -y` to each command. For example:
+All examples in this skill use `playwright-cli` directly. When the binary is not found, prepend `npx -y @playwright/cli` instead of `playwright-cli` in each command. For example:
 
 ```bash
 # Binary available
 playwright-cli open https://example.com
 
-# Binary not available -- use npx -y
-npx -y playwright-cli open https://example.com
+# Binary not available -- use npx with the correct package name
+npx -y @playwright/cli open https://example.com
 ```
 
 ## Output file conventions


### PR DESCRIPTION
## Summary

- Fix all `npx -y playwright-cli` references to use the correct scoped package name `npx -y @playwright/cli`
- The old `playwright-cli` npm package is **deprecated** (v0.262.0) with the message: "use @playwright/cli instead"
- Using `npx -y playwright-cli` installs the deprecated package instead of the current one

## Files changed

- **`custom-sections.md`** -- source of truth for our local additions (persists across upstream syncs)
- **`SKILL.md`** -- assembled output (fixes the currently deployed version)
- **`CHANGELOG.md`**

## Upstream

- Issue: microsoft/playwright-cli#327
- PR: microsoft/playwright-cli#328