### PR TITLE
fix(glab): document correct state filtering flags for issue and MR listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ Changes are grouped by date.
 
 ## [Unreleased]
 
+## [2026-04-08]
+
+### Fixed
+
+- `glab` skill: document correct state filtering for `glab issue list` and `glab mr list` -- `glab` uses `--closed`/`--all` flags, not `--state` (which is a `gh` flag and fails with "Unknown flag")
+
+### Added
+
+- `glab` skill: three new eval cases for issue/MR state filtering (open issues, closed issues, all MRs) testing that agents use `--closed`/`--all` instead of the invalid `--state` flag
+
 ## [2026-04-02]
 
 ### Added

--- a/skills/system/glab/SKILL.md
+++ b/skills/system/glab/SKILL.md
@@ -176,28 +176,14 @@ glab issue reopen 42
 
 ### State filtering (open / closed / all)
 
-`glab issue list` and `glab mr list` do **not** have a `--state` flag (that's `gh`, not `glab`). Using `--state` will fail with "Unknown flag". Instead, state filtering is controlled by these flags:
+`glab` does **not** have a `--state` flag (that's `gh`, not `glab`) — using it fails with "Unknown flag". Use these flags instead:
 
 | What you want | `glab issue list` | `glab mr list` |
 |---|---|---|
-| Open only (default) | `glab issue list` | `glab mr list` |
-| Closed only | `glab issue list --closed` | `glab mr list --closed` |
-| All (open + closed) | `glab issue list --all` | `glab mr list --all` |
-| Merged only | n/a | `glab mr list --merged` |
-
-```bash
-# CORRECT -- open issues (the default, no flag needed):
-glab issue list -R group/project
-
-# CORRECT -- closed issues only:
-glab issue list -R group/project --closed
-
-# CORRECT -- all issues regardless of state:
-glab issue list -R group/project --all
-
-# WRONG -- fails with "Unknown flag: --state":
-glab issue list -R group/project --state opened
-```
+| Open only (default) | _(no flag)_ | _(no flag)_ |
+| Closed only | `--closed` | `--closed` |
+| All (open + closed) | `--all` | `--all` |
+| Merged only | n/a | `--merged` |
 
 > **Closing/reopening with a comment**: `glab issue close` and `glab issue reopen` do not accept `--message`. Add a note first: `glab issue note 42 --message "..."`, then `glab issue close 42`.
 

--- a/skills/system/glab/SKILL.md
+++ b/skills/system/glab/SKILL.md
@@ -174,6 +174,31 @@ glab issue close 42                               # close (ask confirmation firs
 glab issue reopen 42
 ```
 
+### State filtering (open / closed / all)
+
+`glab issue list` and `glab mr list` do **not** have a `--state` flag (that's `gh`, not `glab`). Using `--state` will fail with "Unknown flag". Instead, state filtering is controlled by these flags:
+
+| What you want | `glab issue list` | `glab mr list` |
+|---|---|---|
+| Open only (default) | `glab issue list` | `glab mr list` |
+| Closed only | `glab issue list --closed` | `glab mr list --closed` |
+| All (open + closed) | `glab issue list --all` | `glab mr list --all` |
+| Merged only | n/a | `glab mr list --merged` |
+
+```bash
+# CORRECT -- open issues (the default, no flag needed):
+glab issue list -R group/project
+
+# CORRECT -- closed issues only:
+glab issue list -R group/project --closed
+
+# CORRECT -- all issues regardless of state:
+glab issue list -R group/project --all
+
+# WRONG -- fails with "Unknown flag: --state":
+glab issue list -R group/project --state opened
+```
+
 > **Closing/reopening with a comment**: `glab issue close` and `glab issue reopen` do not accept `--message`. Add a note first: `glab issue note 42 --message "..."`, then `glab issue close 42`.
 
 ### Issue template selection

--- a/skills/system/glab/evals/evals.json
+++ b/skills/system/glab/evals/evals.json
@@ -305,6 +305,46 @@
         "If using `glab ci get`, passes the branch via `-b` flag (not as positional argument)",
         "May use `-d` flag on `glab ci get` for extended job details"
       ]
+    },
+    {
+      "id": 22,
+      "prompt": "Can you list only the open issues on our GitLab project https://gitlab.sparkfabrik.com/sparkfabrik-innovation-team/r-d/ai/poc-drupal-rag-intelligence? I want to see what's still pending.",
+      "expected_output": "The agent should use `glab issue list` without any state flag, since open issues are the default. It must NOT use `--state opened` or `--state open` (those flags do not exist in glab and will fail with 'Unknown flag').",
+      "files": [],
+      "assertions": [
+        "Uses `glab issue list` to list issues",
+        "Does NOT use `--state opened` or `--state open` (not a valid glab flag)",
+        "Does NOT use `--opened` (deprecated flag)",
+        "Lists open issues by relying on the default behavior (no state flag needed) or uses `--all` only if showing all states",
+        "Sets GITLAB_HOST=gitlab.sparkfabrik.com for the self-hosted instance",
+        "Uses `-R` with the correct project path"
+      ]
+    },
+    {
+      "id": 23,
+      "prompt": "Show me all closed issues in project https://gitlab.sparkfabrik.com/team/backend/api -- I want to review what we've completed this quarter.",
+      "expected_output": "The agent should use `glab issue list --closed` to filter for closed issues. It must NOT use `--state closed` (not a valid glab flag).",
+      "files": [],
+      "assertions": [
+        "Uses `glab issue list` with the `--closed` or `-c` flag",
+        "Does NOT use `--state closed` (not a valid glab flag)",
+        "Sets GITLAB_HOST=gitlab.sparkfabrik.com for the self-hosted instance",
+        "Uses `-R` with the correct project path (team/backend/api)",
+        "Does NOT use `gh issue list` or any GitHub-specific tooling"
+      ]
+    },
+    {
+      "id": 24,
+      "prompt": "I need to see all merge requests on our project regardless of whether they're open, closed, or merged. Can you list them? We're on https://gitlab.sparkfabrik.com/team/frontend/app.",
+      "expected_output": "The agent should use `glab mr list --all` to show all merge requests regardless of state. It must NOT use `--state all` or `--state opened` (not valid glab flags).",
+      "files": [],
+      "assertions": [
+        "Uses `glab mr list` with the `--all` or `-A` flag",
+        "Does NOT use `--state all` or `--state` in any form (not a valid glab flag)",
+        "Sets GITLAB_HOST=gitlab.sparkfabrik.com for the self-hosted instance",
+        "Uses `-R` with the correct project path (team/frontend/app)",
+        "Does NOT use `gh pr list` or any GitHub-specific tooling"
+      ]
     }
   ]
 }


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## Summary

- **Problem**: agents using the glab skill tried `--state opened` to filter issues by state, which fails with "Unknown flag" — `--state` is a `gh` (GitHub CLI) flag, not a `glab` flag.
- **Fix**: added a "State filtering" subsection to the Issues section of the glab SKILL.md with a compact reference table showing the correct flags (`--closed`, `--all`, `--merged`).
- **Evals**: added 3 new eval cases (#22, #23, #24) covering open issues, closed issues, and all MRs to verify agents use the correct flags instead of `--state`.

## Eval results

Ran evals across 2 iterations (verbose → compact table). Both iterations scored **16/16** with-skill vs **11/16** baseline.

| Eval | With skill (iter 1) | With skill (iter 2, shorter) | Without skill (baseline) |
|---|---|---|---|
| #22 Open issues | 6/6 | 6/6 | 3/6 — used `--state opened` |
| #23 Closed issues | 5/5 | 5/5 | 4/5 |
| #24 All MRs | 5/5 | 5/5 | 4/5 |

Iteration 2 removed the redundant bash examples (14 fewer lines) with no regression.

## Changes

- `skills/system/glab/SKILL.md`: new "State filtering (open / closed / all)" subsection with a compact comparison table
- `skills/system/glab/evals/evals.json`: 3 new eval cases testing state filtering scenarios
- `CHANGELOG.md`: added entry for 2026-04-08