### PR TITLE
fix(glab): add group API patterns and --paginate concatenation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ Changes are grouped by date.
 
 ## [Unreleased]
 
+## [2026-04-13]
+
+### Added
+
+- `glab` skill: group-level API patterns (list projects in a group, subgroups, descendant projects) in both SKILL.md and `references/api-patterns.md`
+
+### Fixed
+
+- `glab` skill: document `--paginate` concatenation pitfall -- paginated responses produce invalid JSON (`[...][...]`) that breaks `jq`; added `jq -s 'add'` workaround with examples
+
 ## [2026-04-11]
 
 ### Added

--- a/skills/system/glab/SKILL.md
+++ b/skills/system/glab/SKILL.md
@@ -572,7 +572,7 @@ GITLAB_HOST=<hostname> glab mr update 4 --description "## Screenshot
 
 ## `glab api` -- last resort for advanced operations
 
-> **Do NOT use `glab api` when a CLI subcommand can do the job.** For issues, MRs, CI, labels -- always use the dedicated subcommands first. Use `glab api` only for operations not covered by any subcommand (e.g., project members, GraphQL queries, custom endpoints).
+> **Do NOT use `glab api` when a CLI subcommand can do the job.** For issues, MRs, CI, labels -- always use the dedicated subcommands first. Use `glab api` only for operations not covered by any subcommand (e.g., group projects, project members, GraphQL queries, custom endpoints).
 
 ```bash
 glab api projects/:id/members                                        # GET
@@ -581,6 +581,31 @@ glab api -X PUT projects/:id/merge_requests/15 -f title="Updated"   # PUT
 glab api projects/:id/issues --paginate                              # paginate
 ```
 
+> **`--paginate` concatenation:** `--paginate` outputs each page's JSON array back-to-back (`[...][...]`), which is not valid JSON. Always merge with `jq -s 'add'`:
+>
+> ```bash
+> # WRONG -- breaks on multi-page results:
+> glab api projects/:id/issues --paginate | jq '.[].title'
+>
+> # CORRECT:
+> glab api projects/:id/issues --paginate | jq -s 'add | .[].title'
+> ```
+
+### Group-level operations
+
+There is no `glab` subcommand for group operations -- use `glab api` with URL-encoded group paths (slashes as `%2F`):
+
+```bash
+# List projects in a group
+GITLAB_HOST=gitlab.example.com glab api \
+  "groups/team%2Fsubgroup/projects" --paginate | jq -s 'add | .[].name' -r | sort
+
+# Include descendant subgroups
+GITLAB_HOST=gitlab.example.com glab api \
+  "groups/team%2Fsubgroup/projects?include_subgroups=true" --paginate \
+  | jq -s 'add | .[].path_with_namespace' -r
+```
+
 Placeholder variables (auto-resolved inside a git repo): `:id`, `:fullpath`, `:repo`.
 
-For comprehensive API patterns (GraphQL, pagination, advanced queries), read `references/api-patterns.md`.
+For comprehensive API patterns (GraphQL, pagination, groups, advanced queries), read `references/api-patterns.md`.

--- a/skills/system/glab/references/api-patterns.md
+++ b/skills/system/glab/references/api-patterns.md
@@ -6,12 +6,13 @@ This file covers common `glab api` patterns for operations that go beyond the bu
 
 1. [Authentication and basics](#authentication-and-basics)
 2. [Project information](#project-information)
-3. [Repository files](#repository-files)
-4. [Issues (advanced)](#issues-advanced)
-5. [Merge requests (advanced)](#merge-requests-advanced)
-6. [Users and members](#users-and-members)
-7. [Labels and milestones](#labels-and-milestones)
-8. [GraphQL queries](#graphql-queries)
+3. [Groups](#groups)
+4. [Repository files](#repository-files)
+5. [Issues (advanced)](#issues-advanced)
+6. [Merge requests (advanced)](#merge-requests-advanced)
+7. [Users and members](#users-and-members)
+8. [Labels and milestones](#labels-and-milestones)
+9. [GraphQL queries](#graphql-queries)
 
 ---
 
@@ -53,6 +54,18 @@ glab api projects/:id/issues --paginate
 glab api "projects/:id/issues?per_page=100&page=2"
 ```
 
+> **Concatenated arrays:** `--paginate` outputs each page's JSON array back-to-back (`[...][...]`), which is **not valid JSON**. Piping directly to `jq '.[].field'` will fail on multi-page results. Always merge the arrays first with `jq -s 'add'`:
+>
+> ```bash
+> # WRONG -- breaks when response spans multiple pages:
+> glab api projects/:id/issues --paginate | jq '.[].title'
+>
+> # CORRECT -- merge pages into a single array:
+> glab api projects/:id/issues --paginate | jq -s 'add | .[].title'
+> ```
+>
+> For single-page results both forms work, but using `jq -s 'add'` is always safe.
+
 ---
 
 ## Project information
@@ -79,6 +92,36 @@ glab api projects/:id/hooks
 
 ---
 
+## Groups
+
+Group paths must be URL-encoded (slashes as `%2F`), just like project paths.
+
+```bash
+# List projects in a group
+GITLAB_HOST=gitlab.example.com glab api \
+  "groups/team%2Fsubgroup/projects" --paginate \
+  | jq -s 'add | .[] | {name, path_with_namespace, web_url}'
+
+# List projects (names only, sorted)
+GITLAB_HOST=gitlab.example.com glab api \
+  "groups/team%2Fsubgroup/projects" --paginate \
+  | jq -s 'add | .[].name' -r | sort
+
+# Include projects from descendant subgroups
+GITLAB_HOST=gitlab.example.com glab api \
+  "groups/team%2Fsubgroup/projects?include_subgroups=true" --paginate \
+  | jq -s 'add | .[].path_with_namespace' -r
+
+# List subgroups
+GITLAB_HOST=gitlab.example.com glab api \
+  "groups/team/subgroups" | jq '.[].full_path'
+
+# Group details
+GITLAB_HOST=gitlab.example.com glab api "groups/team%2Fsubgroup"
+```
+
+---
+
 ## Repository files
 
 ```bash
@@ -95,8 +138,9 @@ glab api "projects/:id/repository/files/.gitlab-ci.yml?ref=main"
 # List files in a directory
 glab api "projects/:id/repository/tree?ref=main&path=deploy"
 
-# Recursive directory listing
-glab api "projects/:id/repository/tree?ref=main&recursive=true&per_page=100" --paginate
+# Recursive directory listing (use jq -s 'add' with --paginate)
+glab api "projects/:id/repository/tree?ref=main&recursive=true&per_page=100" --paginate \
+  | jq -s 'add | .[].path'
 
 # List files with details (name, type, path)
 glab api "projects/:id/repository/tree?ref=main&path=src" | jq '.[] | {name, type, path}'


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## Summary

- Add group-level API patterns (list projects, subgroups, descendant projects) to both `SKILL.md` and `references/api-patterns.md` -- the skill previously had no guidance for group operations, causing agents to improvise poorly
- Document the `--paginate` concatenation pitfall (`[...][...]` is not valid JSON) with the `jq -s 'add'` workaround, including WRONG/CORRECT examples
- Update existing `--paginate` examples (recursive tree listing) to use the safe pattern