### PR TITLE
docs: remove VS Code Insiders requirement for Agent Skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Changes are grouped by date.
 
 ## [Unreleased]
 
+### Changed
+
+- README: Removed VS Code Insiders requirement for `chat.useAgentSkills` directive -- Agent Skills are now available in the standard VS Code release
+
 ## [2026-04-13]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -46,12 +46,7 @@ Browse the `agents/` directory for available agents.
 
 ### Prerequisites
 
-> ⚠️ **Warning:** Agent Skills support in VS Code is currently in preview and only available in **VS Code Insiders**.
-
-To enable Agent Skills:
-
-1. Install [VS Code Insiders](https://code.visualstudio.com/insiders/)
-2. Enable the setting in your workspace or user settings:
+To enable Agent Skills, set the following configuration in your workspace or user settings:
 
 **Via Settings UI:**
 


### PR DESCRIPTION
Agent Skills are now available in the standard VS Code release. Update README to remove the VS Code Insiders installation step and warning.