### PR TITLE
fix: require human approval before posting to external systems

### DIFF
--- a/skills/drupal/drupal-major-upgrade-validation/SKILL.md
+++ b/skills/drupal/drupal-major-upgrade-validation/SKILL.md
@@ -416,6 +416,20 @@ Validation screenshots: `.playwright-cli/validation/`
 <list any issues found, recommended fixes, or follow-up actions>
 ```
 
+### Posting Results to External Systems
+
+**IMPORTANT: Never post reports, comments, or any content to external systems
+(GitLab issues, GitHub PRs, Slack, etc.) without explicit human approval.**
+
+Before posting:
+1. Show the full report content to the user in the conversation.
+2. Ask for explicit confirmation to post (e.g., "Shall I post this to issue #N?").
+3. Only post after the user approves. If the user requests changes, revise and
+   show again before posting.
+
+This applies to all external interactions: creating issue comments, uploading
+attachments referenced in reports, updating issue labels or status, etc.
+
 ### Status Classification
 
 - **PASS:** Page works identically or better in the upgraded version


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @Bladedu._

## Summary

- Adds a \"Posting Results to External Systems\" section to the drupal-major-upgrade-validation skill
- Requires the agent to show the full report to the user and get explicit confirmation before posting to GitLab issues, GitHub PRs, or any external system
- Learned from a real validation session where the report was posted without asking first