### PR TITLE
fix(glab): document -f vs -F file reading difference in glab api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Changes are grouped by date.
 
 - README: Removed VS Code Insiders requirement for `chat.useAgentSkills` directive -- Agent Skills are now available in the standard VS Code release
 
+### Fixed
+
+- `glab` skill: document `-f` vs `-F` flag difference for `glab api` — `-f key=@file` sends the literal string while `-F key=@file` reads the file content; using the wrong flag silently corrupts note/description updates
+
 ## [2026-04-13]
 
 ### Added

--- a/skills/system/glab/SKILL.md
+++ b/skills/system/glab/SKILL.md
@@ -581,6 +581,20 @@ glab api -X PUT projects/:id/merge_requests/15 -f title="Updated"   # PUT
 glab api projects/:id/issues --paginate                              # paginate
 ```
 
+### `-f` vs `-F` -- file reading with `@`
+
+`-f key=@file` sends the **literal string** `@file` as the value. `-F key=@file` **reads the file** and sends its content. Using `-f` with `@` silently corrupts the data -- no error, just the wrong value.
+
+```bash
+# WRONG -- sends literal "@/tmp/body.txt":
+glab api -X PUT projects/:id/issues/42/notes/99999 -f body=@/tmp/body.txt
+
+# CORRECT -- sends file content:
+glab api -X PUT projects/:id/issues/42/notes/99999 -F body=@/tmp/body.txt
+```
+
+Use `-f` for short inline values (`-f title="Bug fix"`), `-F` for file-backed content (`-F body=@/tmp/note.txt`).
+
 > **`--paginate` concatenation:** `--paginate` outputs each page's JSON array back-to-back (`[...][...]`), which is not valid JSON. Always merge with `jq -s 'add'`:
 >
 > ```bash


### PR DESCRIPTION
## Summary

- Adds a subsection to the `glab api` section documenting the silent difference between `-f` and `-F` when using `@file` syntax: `-f` sends the literal string `@/path`, `-F` reads the file content.
- Discovered while bulk-updating 9 GitLab issue notes — `-f body=@file` replaced all note bodies with the file path string instead of the content.