### PR TITLE
feat(skills): Add some skills for Drupal development

### DIFF
--- a/skills/drupal/drupal-ddd/SKILL.md
+++ b/skills/drupal/drupal-ddd/SKILL.md
@@ -1,0 +1,437 @@
+---
+name: drupal-ddd
+description: >-
+  Apply Domain-Driven Design patterns in Drupal 11 custom modules. Covers both
+  strategic design (Bounded Contexts, Ubiquitous Language, Context Maps) and
+  tactical patterns (Value Objects, Entities, Aggregates, Domain Services,
+  Domain Events, Factories, Application Services, Anti-Corruption Layers).
+  Also covers the mandatory Repository Design Pattern for ALL entity interactions —
+  any code involving EntityTypeManager, EntityStorage, entity queries, or entity
+  CRUD operations must follow the repository architecture documented here.
+  All patterns are adapted from classic DDD (as taught in the "DDD in PHP" book)
+  to work with Drupal's Entity API and PDO-based storage instead of Doctrine ORM.
+  Use this skill whenever designing module architecture, modeling a complex domain
+  in Drupal, deciding how to structure business logic, or when terms like
+  "value object", "aggregate", "domain event", "bounded context", "rich model",
+  "anemic model", "application service", "domain service", "anti-corruption layer",
+  "repository", "repository pattern", or "hexagonal architecture" come up.
+  Also use when writing or reviewing code that loads, queries, saves, or deletes
+  Drupal entities. Also use when the user is deciding how to split responsibilities
+  across Drupal modules, wants to avoid fat controllers or hook-heavy architectures,
+  needs to integrate with external APIs cleanly, or asks about structuring complex
+  business rules in Drupal. Even for questions like "where should this logic go?"
+  or "how should I organize this module?" — this skill provides the architectural
+  framework for making those decisions.
+---
+
+# Domain-Driven Design in Drupal
+
+This skill teaches how to apply DDD principles in Drupal 11 custom modules.
+Drupal uses a PDO-based Entity API (not Doctrine ORM), so every pattern here
+is adapted to work with `EntityTypeManager`, entity queries, Drupal's service
+container, and the hook/event system.
+
+The **Repository Pattern** is a core DDD building block and is **mandatory** in
+this project for ALL entity interactions. See `references/repository-pattern.md`
+for the full implementation guide. This skill covers the broader DDD landscape —
+Value Objects, Entities, Aggregates, Services, Events, and integration patterns —
+and shows how they work alongside repositories in Drupal.
+
+## How This Skill Is Organized
+
+- **SKILL.md** (this file): Strategic design + tactical pattern overview with
+  decision guidance. Read this first.
+- **references/repository-pattern.md**: The mandatory Repository Design Pattern —
+  interface definition, concrete implementation, service registration, directory
+  structure, correct/incorrect examples, and edge cases.
+- **references/value-objects.md**: Deep dive into Value Objects in Drupal — when
+  to use them, how to persist them, testing patterns.
+- **references/entities-aggregates.md**: Rich Entities, Aggregate design rules,
+  invariant enforcement in Drupal's entity system.
+- **references/services-and-events.md**: Domain Services vs Application Services,
+  Domain Events via Symfony EventDispatcher, the Anemic Model trap.
+- **references/bounded-contexts.md**: Strategic design — modules as Bounded
+  Contexts, Anti-Corruption Layers, integration patterns.
+
+Read the relevant reference file when you need implementation details for a
+specific pattern.
+
+---
+
+## Strategic Design: The Big Picture
+
+### Ubiquitous Language
+
+The Ubiquitous Language is a shared vocabulary between developers and domain
+experts. In Drupal, this means:
+
+- **Content type names** use domain terms, not technical labels
+  (e.g., `course_of_study` not `academic_content_type_3`)
+- **Field names** reflect what the business calls them
+  (e.g., `field_enrollment_deadline` not `field_date_2`)
+- **Module names** represent domain concepts
+  (e.g., `my_project_access` for access control, not `my_project_perms_util`)
+- **Service class names** read as domain operations
+  (e.g., `EnrollmentVerifier`, not `DataProcessor`)
+
+When a domain expert says "a student enrolls in a course of study," the code
+should contain classes named `Student`, `CourseOfStudy`, and a method called
+`enroll()`. If the code uses different terms, communication breaks down and
+bugs follow.
+
+### Bounded Contexts
+
+A Bounded Context is a boundary within which a particular domain model applies.
+In Drupal, **each custom module is a natural Bounded Context**:
+
+```
+my_project_access/       → Access Control context (Groups, Permissions, Sections)
+my_project_catalog/      → Product Catalog context (Products, Categories, Pricing)
+my_project_crm/          → CRM Integration context (Contacts, Sync, External API)
+my_project_content/      → Core Content context (Pages, Navigation, Layout)
+```
+
+**Rules for Bounded Context boundaries:**
+
+1. Each module owns its domain model — its entity types, value objects, and
+   business rules. Other modules interact through **published interfaces**
+   (services, events), never by reaching into another module's internals.
+
+2. The same real-world concept may have different representations in different
+   contexts. A "User" in an access control module cares about group membership;
+   a "User" in a CRM module cares about sync history. Each context defines its
+   own interface for the aspects it needs.
+
+3. Shared code between contexts should be minimal. If two modules need the same
+   utility, extract it to a shared library module, but keep domain logic within
+   its owning module.
+
+### Context Maps and Integration Patterns
+
+When modules need to communicate, choose the right integration pattern:
+
+| Pattern                   | When to Use                                  | Drupal Implementation                                                      |
+|---------------------------|----------------------------------------------|----------------------------------------------------------------------------|
+| **Published Language**    | Modules agree on a shared data format        | Shared interfaces in a base module                                         |
+| **Customer-Supplier**     | One module serves another's needs            | Service interface in supplier, consumer injects it                         |
+| **Anti-Corruption Layer** | Integrating with external/legacy systems     | Adapter service that translates external API responses into domain objects |
+| **Conformist**            | You must accept another system's model as-is | Direct mapping with minimal translation                                    |
+| **Separate Ways**         | No meaningful relationship                   | Modules don't interact at all                                              |
+
+For detailed implementation guidance on integration patterns and ACLs, read
+`references/bounded-contexts.md`.
+
+---
+
+## Tactical Patterns: Decision Guide
+
+The hardest part of DDD is knowing **which pattern to reach for**. Use this
+decision tree when designing a feature:
+
+### "Where does this logic belong?"
+
+```
+Is it a concept with no identity, defined only by its attributes?
+  → VALUE OBJECT (Email, Money, DateRange, Slug, PostalCode)
+  → See references/value-objects.md
+
+Is it a concept with identity that changes over time?
+  → ENTITY (Node, User, Order, Product)
+  → See references/entities-aggregates.md
+
+Is it a cluster of entities that must be consistent together?
+  → AGGREGATE (Node + its Paragraphs, Order + its LineItems)
+  → See references/entities-aggregates.md
+
+Is it an operation that doesn't naturally belong to any entity?
+  → DOMAIN SERVICE (authentication, cross-entity calculations)
+  → See references/services-and-events.md
+
+Is it an orchestration of multiple steps (load, validate, save, notify)?
+  → APPLICATION SERVICE (form submit handler, API endpoint logic)
+  → See references/services-and-events.md
+
+Is it something significant that happened in the domain?
+  → DOMAIN EVENT (UserRegistered, OrderPlaced, PaymentReceived)
+  → See references/services-and-events.md
+
+Does it create complex objects with business rules?
+  → FACTORY (entity creation with invariant checks)
+  → See references/entities-aggregates.md
+```
+
+### "Is DDD overkill here?"
+
+DDD is not always the answer. Use this checklist:
+
+- **Simple CRUD** with no business rules beyond validation → Use Drupal's
+  built-in entity forms and validation constraints. No need for domain objects.
+- **Configuration pages** → Use `ConfigFormBase`. No domain modeling needed.
+- **Display logic** (how things look) → Theme layer, SDC components. Not domain.
+- **Complex business rules**, state machines, cross-entity consistency,
+  external integrations → DDD patterns shine here.
+
+The goal is not to apply every pattern everywhere, but to use the right pattern
+where complexity justifies it. A module with 3 fields and no business logic
+doesn't need Value Objects and Aggregates. A module integrating with an external
+ERP and enforcing business rules does.
+
+---
+
+## Tactical Pattern Quick Reference
+
+### Value Objects
+
+Immutable objects defined by their attributes, not identity. Use them to replace
+primitive types (`string`, `int`) with domain-meaningful types.
+
+```php
+// Instead of passing raw strings around:
+function sendEmail(string $to, string $subject): void;
+
+// Use Value Objects that self-validate:
+function sendEmail(EmailAddress $to, Subject $subject): void;
+```
+
+**When to use in Drupal:**
+- Complex field values (Money = amount + currency, DateRange = start + end)
+- Domain concepts that appear in multiple places (PostalCode, IsoLanguageCode)
+- Anything where validation rules exist (email format, currency codes)
+
+**Drupal-specific:** Drupal fields are already a form of persistence-level value
+objects. PHP Value Objects add domain-level validation and behavior on top.
+Convert between them at the repository boundary.
+
+Read `references/value-objects.md` for full implementation details.
+
+### Entities and Aggregates
+
+Entities have identity and mutable state. Aggregates are clusters of entities
+with a root that enforces consistency.
+
+**In Drupal**, content entities (nodes, taxonomy terms, custom entities) are
+already entities with identity. The DDD contribution is:
+
+1. **Rich behavior** — push business logic into entity methods instead of
+   spreading it across hooks and services
+2. **Aggregate boundaries** — a node + its paragraphs form a natural aggregate;
+   the node is the root
+3. **Invariant enforcement** — use `hook_entity_presave` or custom validation
+   constraints to enforce business rules
+
+Read `references/entities-aggregates.md` for patterns.
+
+### Domain Services
+
+Stateless operations that don't belong to any single entity. In Drupal, these
+are registered as services in `*.services.yml`.
+
+```php
+// Domain Service: operates on domain concepts, no infrastructure dependency
+final readonly class EnrollmentEligibilityChecker {
+  public function isEligible(Student $student, CourseOfStudy $course): bool {
+    // Business rule: check prerequisites, capacity, deadlines
+  }
+}
+```
+
+**The Anemic Model trap:** Drupal's architecture naturally pushes toward entities
+as data bags with all logic in services/hooks. Fight this by asking: "Could this
+logic live on the entity itself?" If the logic needs only the entity's own data,
+it belongs on the entity.
+
+Read `references/services-and-events.md` for the full picture.
+
+### Domain Events
+
+Record that something significant happened. In Drupal, use Symfony's
+EventDispatcher for synchronous events, or Drupal's Queue API / Symfony
+Messenger for async.
+
+```php
+// Event class (immutable record of what happened)
+final readonly class OrderWasPlaced {
+  public function __construct(
+    public string $orderId,
+    public string $customerId,
+    public \DateTimeImmutable $occurredOn,
+  ) {}
+}
+```
+
+**When to use instead of hooks:**
+- When the side-effect is in a different Bounded Context
+- When you need an audit trail of domain changes
+- When the reaction can happen asynchronously
+- When you want to decouple the triggering code from the reacting code
+
+Read `references/services-and-events.md` for implementation patterns.
+
+### Application Services
+
+Thin orchestrators that coordinate domain operations. In Drupal, these sit
+between the controller/form layer and the domain:
+
+```php
+final readonly class PlaceOrderService {
+  public function __construct(
+    private OrderRepositoryInterface $orders,
+    private InventoryServiceInterface $inventory,
+    private EventDispatcherInterface $events,
+  ) {}
+
+  public function execute(string $customerId, array $items): OrderOutcome {
+    $order = Order::createDraft($customerId, $items);
+    $this->inventory->reserve($items);
+    $this->orders->save($order);
+    $this->events->dispatch(new OrderWasPlaced($order->id(), $customerId));
+    return OrderOutcome::placed((string) $order->id());
+  }
+}
+```
+
+**Rules:**
+- No business logic in application services — delegate to entities/domain services
+- Accept primitive types or DTOs as input (not entities)
+- Return DTOs or Value Objects (not entities) to the presentation layer
+- Handle transactions at this level
+
+Read `references/services-and-events.md` for details.
+
+---
+
+## Module Directory Structure
+
+This is the recommended structure for a DDD-oriented Drupal module. Not every
+module needs every directory — use what fits the complexity:
+
+```
+web/modules/custom/my_module/
+├── my_module.info.yml
+├── my_module.module              # Thin: delegates to Hook classes
+├── my_module.services.yml        # DI wiring
+├── src/
+│   ├── Domain/                   # Domain settings, constants, specifications
+│   │   └── Settings.php          # Config wrapper (domain concept names)
+│   ├── Entity/                   # Entity classes + repository interfaces
+│   │   ├── Order/
+│   │   │   ├── Order.php         # Drupal entity with rich behavior
+│   │   │   ├── OrderInterface.php
+│   │   │   └── OrderRepositoryInterface.php
+│   │   ├── Contrib/              # Repo interfaces for contrib entities
+│   │   │   └── NodeRepositoryInterface.php
+│   │   └── ValueObject/          # Pure PHP value objects
+│   │       ├── Money.php
+│   │       └── PostalCode.php
+│   ├── Infrastructure/
+│   │   └── Persistence/
+│   │       └── Repository/       # Concrete repository implementations
+│   │           └── OrderRepository.php
+│   ├── Service/                  # Application services (orchestrators)
+│   │   └── PlaceOrderService.php
+│   ├── Event/                    # Domain events
+│   │   └── OrderWasPlaced.php
+│   ├── EventSubscriber/          # Event listeners (reactions)
+│   ├── Messenger/                # Async message classes + handlers
+│   ├── Hook/                     # Drupal hook implementations
+│   ├── Controller/               # Route controllers (thin)
+│   ├── Form/                     # Drupal forms
+│   ├── Plugin/                   # Drupal plugins
+│   ├── Presentation/             # UI-facing services, Twig extensions
+│   │   └── Acl/                  # Access policies
+│   ├── Adapter/                  # Adapter pattern (domain interface wrappers)
+│   ├── Exception/                # Domain-specific exceptions
+│   └── Trait/                    # Reusable traits
+```
+
+**Key principles:**
+- Group by domain concept within `Entity/`, not by architectural role
+- `Entity/ValueObject/` holds pure PHP classes with no Drupal dependency
+- Repository interfaces live next to the entities they serve
+- Infrastructure code (persistence, external APIs) stays in `Infrastructure/`
+- Keep controllers and forms thin — they delegate to services
+
+---
+
+## Layered Architecture in Drupal
+
+DDD organizes code into layers with strict dependency rules:
+
+```
+┌─────────────────────────────────────────────┐
+│  Presentation Layer                         │
+│  Controllers, Forms, Twig, SDC, Hooks       │
+│  → Can depend on: Application, Domain       │
+├─────────────────────────────────────────────┤
+│  Application Layer                          │
+│  Application Services, DTOs, Commands       │
+│  → Can depend on: Domain                    │
+├─────────────────────────────────────────────┤
+│  Domain Layer                               │
+│  Entities, Value Objects, Domain Services,  │
+│  Repository Interfaces, Domain Events       │
+│  → Depends on: NOTHING (pure PHP)           │
+├─────────────────────────────────────────────┤
+│  Infrastructure Layer                       │
+│  Repository Implementations, API Clients,   │
+│  Messaging, File Storage                    │
+│  → Implements: Domain interfaces            │
+│  → Can depend on: Domain, Drupal APIs       │
+└─────────────────────────────────────────────┘
+```
+
+The critical rule: **the Domain layer has no dependencies on Drupal APIs**.
+Value Objects, Domain Services, and Domain Events are pure PHP. This makes
+them testable without bootstrapping Drupal.
+
+The exception: Drupal Entity classes (in `Entity/`) necessarily depend on
+Drupal's Entity API. This is a pragmatic compromise — Drupal entities are both
+domain objects and persistence objects. Enrich them with behavior, but keep
+complex business logic in separate domain classes when possible.
+
+---
+
+## Anti-Patterns to Avoid
+
+### 1. Anemic Domain Model
+**Symptom:** Entities are data bags with getters/setters. All logic lives in
+services, hooks, or form handlers.
+
+```php
+// BAD: Entity is just a data container
+$order->set('status', 'accepted');
+$order->set('updated', new \DateTimeImmutable());
+$order->save();
+
+// GOOD: Entity encapsulates behavior
+$order->accept(); // internally sets status + timestamp + records event
+```
+
+### 2. Fat Controllers / Fat Hooks
+**Symptom:** Controllers or hook implementations contain 50+ lines of business
+logic, entity queries, and conditional branching.
+
+**Fix:** Extract to an Application Service that orchestrates domain operations.
+The controller just calls the service and returns a response.
+
+### 3. Primitive Obsession
+**Symptom:** Passing `string $email`, `float $amount`, `string $currency_code`
+everywhere instead of typed Value Objects.
+
+**Fix:** Create `EmailAddress`, `Money`, `CurrencyCode` value objects that
+self-validate on construction. Invalid values can't exist.
+
+### 4. Shared Database / Shared Kernel Creep
+**Symptom:** Module A directly queries Module B's database tables or reaches
+into its entity storage.
+
+**Fix:** Module B exposes a service interface. Module A injects and calls that
+interface. If the integration is with an external system, use an
+Anti-Corruption Layer.
+
+### 5. Event Handlers with Business Logic
+**Symptom:** An event subscriber contains complex business rules instead of
+simply reacting to an event.
+
+**Fix:** The event subscriber should delegate to a Domain Service or
+Application Service. It's a thin dispatcher, not a business logic container.

--- a/skills/drupal/drupal-ddd/references/bounded-contexts.md
+++ b/skills/drupal/drupal-ddd/references/bounded-contexts.md
@@ -1,0 +1,451 @@
+# Bounded Contexts and Integration Patterns in Drupal
+
+## Table of Contents
+
+1. [Modules as Bounded Contexts](#modules-as-bounded-contexts)
+2. [Context Mapping](#context-mapping)
+3. [Anti-Corruption Layer](#anti-corruption-layer)
+4. [Integration Patterns](#integration-patterns)
+5. [Cross-Module Communication](#cross-module-communication)
+6. [Hexagonal Architecture in Drupal](#hexagonal-architecture-in-drupal)
+
+---
+
+## Modules as Bounded Contexts
+
+A Bounded Context is a boundary within which a particular domain model applies.
+The key insight: **the same real-world concept can have different meanings in
+different contexts.**
+
+A "User" in an Access Control context is a principal with roles and permissions.
+A "User" in a CRM Integration context is a contact with sync metadata. These
+are different models of the same real-world thing, and they should live in
+different modules.
+
+### How Drupal Modules Map to Bounded Contexts
+
+Each custom Drupal module should own a coherent slice of the domain:
+
+```
+my_project_access/       → Access Control BC
+  - Group entity, group membership, section-based access
+  - "User" here = UserWithGroupsInterface (groups, permissions)
+
+my_project_catalog/      → Product Catalog BC
+  - Product, Category, Pricing entities
+  - "Product" here = something with inventory and pricing rules
+
+my_project_crm/          → CRM Integration BC
+  - Contact sync, field mapping, submission tracking
+  - "Contact" here = data packet for the external CRM system
+
+my_project_content/      → Core Content BC
+  - Base content, homepage, common settings
+  - "Page" here = navigational content with SEO and layout
+```
+
+### Module Boundary Rules
+
+1. **Own your entities.** A module's entity types, their fields, and their
+   storage logic belong exclusively to that module.
+
+2. **Expose through interfaces.** If another module needs data from yours,
+   expose a service interface. Don't let them query your tables directly.
+
+3. **Don't share entity classes.** If two modules both need "Node" data,
+   each creates its own `NodeRepositoryInterface` with the specific methods
+   it needs. They don't share a single god-repository.
+
+4. **Separate the language.** Each module can have its own vocabulary.
+   `field_access_groups` means something specific in the access module;
+   another module shouldn't interpret it.
+
+5. **Configuration ownership.** Each module exports and manages its own
+   configuration. Cross-module config dependencies should be explicit
+   (via `dependencies:` in `.info.yml`).
+
+---
+
+## Context Mapping
+
+A Context Map shows the relationships between Bounded Contexts. In Drupal,
+these relationships manifest as module dependencies and service interfaces.
+
+### Relationship Types
+
+**Customer-Supplier (Upstream/Downstream)**
+
+One module supplies data that another consumes. The supplier defines the
+interface; the consumer adapts.
+
+```
+my_project_catalog (Supplier)  →  my_project_content (Customer)
+  ProductRepositoryInterface         Loads product data to display on pages
+```
+
+```yaml
+# In my_project_content.info.yml
+dependencies:
+  - my_project_catalog:my_project_catalog
+```
+
+**Conformist**
+
+You accept another system's model without translation. Common when using
+contrib modules as-is:
+
+```
+Drupal Core User  →  my_project_access
+  my_project_access accepts Drupal's User entity model
+  and wraps it with UserWithGroupsInterface
+```
+
+**Anti-Corruption Layer (ACL)**
+
+When integrating with an external system whose model doesn't match yours,
+insert a translation layer. This is the most important integration pattern
+for Drupal sites that talk to external APIs.
+
+**Separate Ways**
+
+Two modules have no interaction. Most Drupal modules fall into this category.
+
+---
+
+## Anti-Corruption Layer
+
+The ACL is a shield between your domain model and an external system's model.
+It translates external data into your domain's language so your code never
+depends on external structures.
+
+### Why It Matters
+
+Without an ACL, external API changes ripple through your codebase:
+
+```php
+// BAD: External API structure leaks into domain code
+class ProductService {
+  public function findProduct(string $id): array {
+    $response = $this->httpClient->get("/api/v2/products/{$id}");
+    $data = json_decode($response->getBody(), TRUE);
+    // Now your entire codebase depends on the API's JSON structure
+    return [
+      'name' => $data['product_name'],
+      'price' => $data['unit_price_cents'] / 100,
+      'sku' => $data['stock_keeping_unit'],
+    ];
+  }
+}
+```
+
+With an ACL, the translation is isolated:
+
+```php
+// GOOD: Anti-Corruption Layer translates at the boundary
+// 1. Adapter (talks to external API)
+class ExternalCatalogAdapter implements ProductProviderInterface {
+  public function __construct(
+    private readonly HttpClientInterface $httpClient,
+    private readonly ExternalProductTranslator $translator,
+  ) {}
+
+  public function findProduct(string $externalId): ?Product {
+    $response = $this->httpClient->get("/api/v2/products/{$externalId}");
+    $data = json_decode($response->getBody(), TRUE);
+    return $this->translator->toDomainModel($data);
+  }
+}
+
+// 2. Translator (converts external → domain)
+class ExternalProductTranslator {
+  public function toDomainModel(array $apiData): Product {
+    return new Product(
+      name: $apiData['product_name'] ?? '',
+      price: Money::ofCents((int) ($apiData['unit_price_cents'] ?? 0), 'USD'),
+      sku: $apiData['stock_keeping_unit'] ?? '',
+    );
+  }
+}
+
+// 3. Domain interface (what the domain needs — no external concepts)
+interface ProductProviderInterface {
+  public function findProduct(string $externalId): ?Product;
+}
+```
+
+### ACL Components
+
+| Component             | Role                          | Drupal Location                            |
+|-----------------------|-------------------------------|--------------------------------------------|
+| **Domain Interface**  | Defines what the domain needs | `src/Entity/` or `src/Domain/`             |
+| **Adapter**           | Talks to the external system  | `src/Infrastructure/`                      |
+| **Translator/Mapper** | Converts external → domain    | `src/Infrastructure/` or `src/Service/`    |
+| **Domain Model**      | Your internal representation  | `src/Entity/` or `src/Entity/ValueObject/` |
+
+### Exception Hierarchy
+
+External system errors should be wrapped in domain-specific exceptions:
+
+```php
+// Base exception for the external integration
+class ExternalSystemException extends \RuntimeException {}
+
+// Specific failure modes
+class AuthenticationFailedException extends ExternalSystemException {}
+class RateLimitExceededException extends ExternalSystemException {
+  public function __construct(
+    public readonly int $retryAfterSeconds,
+  ) {
+    parent::__construct('Rate limit exceeded');
+  }
+}
+class ResourceNotFoundException extends ExternalSystemException {}
+```
+
+This pattern isolates external error semantics from your domain. Your
+application services catch `ExternalSystemException` subtypes and handle
+them with domain-appropriate responses (retry, skip, fail gracefully).
+
+---
+
+## Integration Patterns
+
+### Synchronous Integration (Service Calls)
+
+Direct service injection — the simplest integration between modules:
+
+```php
+// Module A injects Module B's service interface
+class ContentDisplayService {
+  public function __construct(
+    private readonly GroupRepositoryInterface $groups,
+  ) {}
+
+  public function getAccessibleContent(string $userId): array {
+    $userGroups = $this->groups->loadGroupsForUser($userId);
+    // ... filter content by groups
+  }
+}
+```
+
+**When to use:** The caller needs the result immediately, and both modules
+are always deployed together.
+
+### Asynchronous Integration (Events + Message Queue)
+
+For operations that can tolerate delay or must not block the current request:
+
+```php
+// Module A dispatches an event
+$this->eventDispatcher->dispatch(new ContentWasPublished($nodeId));
+
+// Module B subscribes to react
+class ExternalSearchIndexSubscriber implements EventSubscriberInterface {
+  public static function getSubscribedEvents(): array {
+    return [ContentWasPublished::class => 'onContentPublished'];
+  }
+
+  public function onContentPublished(ContentWasPublished $event): void {
+    // Queue the indexing work for async processing
+    $this->messageBus->dispatch(
+      new IndexContentInExternalSearch($event->nodeId)
+    );
+  }
+}
+```
+
+**When to use:**
+- Side effects that can happen later (sending emails, updating search index)
+- External system integration that might be slow or unreliable
+- Operations that should not fail the current request if they error
+
+### REST API Integration
+
+When modules live in separate applications or you integrate with third-party
+APIs:
+
+```php
+// Published Language: define the shared data contract
+final readonly class ProductApiResponse {
+  public function __construct(
+    public string $id,
+    public string $name,
+    public float $price,
+    public string $currency,
+  ) {}
+
+  public static function fromArray(array $data): self {
+    return new self(
+      id: $data['id'],
+      name: $data['name'],
+      price: $data['price'],
+      currency: $data['currency'],
+    );
+  }
+}
+```
+
+---
+
+## Cross-Module Communication
+
+### Drupal Queue API (Built-in Async)
+
+For simple async work within a single Drupal installation:
+
+```php
+// Enqueue work
+$queue = \Drupal::queue('my_module_sync');
+$queue->createItem(['order_id' => $id]);
+
+// Queue worker plugin processes it
+#[QueueWorker(
+  id: 'my_module_sync',
+  title: new TranslatableMarkup('Sync orders'),
+  cron: ['time' => 60],
+)]
+class SyncQueueWorker extends QueueWorkerBase {
+  public function processItem($data): void {
+    $this->syncService->sync($data['order_id']);
+  }
+}
+```
+
+### Symfony Messenger (Advanced Async)
+
+For more sophisticated async processing with retry, routing, and transports:
+
+```php
+// Dispatch message
+$this->messageBus->dispatch(
+  new ProcessExternalData($recordId, $sourceSystem)
+);
+
+// Handler processes it (possibly on a different worker)
+#[AsMessageHandler]
+class ProcessExternalDataHandler {
+  public function __invoke(ProcessExternalData $message): void {
+    // Heavy processing here
+  }
+}
+```
+
+### Choosing the Right Integration
+
+| Need                      | Pattern           | Drupal Tool                            |
+|---------------------------|-------------------|----------------------------------------|
+| Simple side effect        | Symfony Event     | `EventDispatcherInterface`             |
+| Background job            | Queue             | `\Drupal::queue()`                     |
+| Reliable async with retry | Messenger         | Symfony Messenger                      |
+| Cross-module data access  | Service interface | Service container DI                   |
+| External API              | ACL + HTTP Client | `\Drupal::httpClient()` behind adapter |
+| Real-time sync            | REST endpoint     | Custom route + controller              |
+
+---
+
+## Hexagonal Architecture in Drupal
+
+Hexagonal Architecture (Ports and Adapters) is the architectural style
+recommended by the DDD in PHP book. It maps naturally to Drupal:
+
+```
+                    ┌───────────────────────────────────┐
+                    │                                   │
+   HTTP Request ───→│  Port: Controller                 │
+                    │    ↓                              │
+   Form Submit ────→│  Port: Form Handler               │
+                    │    ↓                              │
+   Drush Command ──→│  Port: Drush Command              │
+                    │    ↓                              │
+                    │  Application Service              │
+                    │    ↓                              │
+                    │  Domain (Entities, VOs, Services) │
+                    │    ↓                              │
+                    │  Port: Repository Interface       │───→ Adapter: EntityStorage
+                    │  Port: ExternalAPI Interface      │───→ Adapter: HTTP Client
+                    │  Port: Notification Interface     │───→ Adapter: Mail Manager
+                    │                                   │
+                    └───────────────────────────────────┘
+```
+
+### Ports = Interfaces
+
+**Driving ports** (input): How the outside world triggers your domain logic
+- Controllers, Forms, Drush Commands, Queue Workers, Event Subscribers
+
+**Driven ports** (output): How your domain reaches the outside world
+- Repository interfaces, External API interfaces, Notification interfaces
+
+### Adapters = Implementations
+
+Each port has one or more adapters:
+- `NodeRepositoryInterface` → `DrupalNodeRepository` (production),
+  `InMemoryNodeRepository` (test)
+- `ExternalApiInterface` → `HttpExternalApiClient` (production),
+  `StubExternalApi` (test)
+
+### The Key Benefit
+
+Your domain code (entities, value objects, domain services) depends on
+**ports** (interfaces), never on **adapters** (implementations). This means:
+
+1. **Testability** — swap adapters for in-memory stubs in tests
+2. **Flexibility** — change infrastructure without touching domain code
+3. **Clarity** — the domain expresses what it needs, not how it's done
+
+---
+
+## Example: Full ACL for External API Integration
+
+Here's a complete example of integrating a Drupal module with an external
+product catalog API using the Anti-Corruption Layer pattern:
+
+```
+External Product Catalog API
+  ↓ (raw JSON response)
+ExternalCatalogClient (Infrastructure — HTTP adapter)
+  ↓ (raw array data)
+ExternalProductTranslator (Infrastructure — translator)
+  ↓ (Product domain object)
+ProductRepository (Infrastructure/Persistence)
+  ↓ (persisted to Drupal storage)
+```
+
+Key classes:
+
+- **`ExternalCatalogClient`** — handles HTTP calls, authentication, error
+  wrapping. Only class that knows about the API's URL structure and auth.
+- **`ExternalProductTranslator`** — maps API response fields to domain
+  Value Objects and entities. Only class that knows about the API's field names.
+- **`ProductProviderInterface`** — domain interface. The rest of the
+  application depends on this, never on the HTTP client or translator.
+- **`ExternalSystemException` hierarchy** — wraps HTTP errors into
+  domain-meaningful exceptions.
+
+The benefit: when the external API changes (field names, auth mechanism,
+versioning), only the adapter and translator need updates. Your domain code,
+application services, and controllers remain untouched.
+
+### Integration Architecture Diagram
+
+```
+my_project_content ←──(service call)──→ my_project_catalog
+  ↑                                          ↑
+  │ (depends on)                      (REST API)
+  │                                          │
+  ↓                                          ↓
+my_project_access                    External Catalog API
+  ↑
+  │ (adapts core entities)
+  │
+  ↓
+Drupal Core (Node, User, MenuLink)
+
+my_project_crm ←──(async message)──→ External CRM System
+```
+
+Each arrow represents a specific integration pattern:
+- **Service call**: direct DI injection of interfaces
+- **REST API**: Anti-Corruption Layer with adapter + translator
+- **Async message**: Symfony Messenger for reliable sync
+- **Adapts**: Adapter pattern wrapping core entities

--- a/skills/drupal/drupal-ddd/references/entities-aggregates.md
+++ b/skills/drupal/drupal-ddd/references/entities-aggregates.md
@@ -1,0 +1,547 @@
+# Entities, Aggregates, and Factories in Drupal
+
+## Table of Contents
+
+1. [Rich Entities vs Anemic Entities](#rich-entities-vs-anemic-entities)
+2. [Identity in Drupal](#identity-in-drupal)
+3. [Making Drupal Entities Rich](#making-drupal-entities-rich)
+4. [Aggregates](#aggregates)
+5. [Aggregate Design Rules](#aggregate-design-rules)
+6. [Factories](#factories)
+7. [Concurrency and Consistency](#concurrency-and-consistency)
+
+---
+
+## Rich Entities vs Anemic Entities
+
+In DDD, an Entity has identity, state, and **behavior**. The entity is
+responsible for protecting its own invariants — the business rules that must
+always be true.
+
+### The Anemic Model Problem
+
+Drupal's architecture makes it easy to fall into the Anemic Domain Model:
+entities become data containers, and all logic lives in hooks, services, or
+form handlers.
+
+```php
+// ANEMIC (common in Drupal, but problematic for complex domains):
+// Logic scattered across hooks and services
+function my_module_entity_presave(EntityInterface $entity): void {
+  if ($entity->bundle() === 'order') {
+    if ($entity->get('field_status')->value === 'accepted') {
+      $entity->set('field_accepted_at', date('Y-m-d'));
+      $entity->set('field_accepted_by', \Drupal::currentUser()->id());
+    }
+  }
+}
+
+// RICH (DDD approach):
+// Logic lives on the entity itself
+class Order extends ContentEntityBase implements OrderInterface {
+
+  public function accept(AccountInterface $acceptedBy): void {
+    if ($this->isAccepted()) {
+      throw new OrderAlreadyAcceptedException($this->id());
+    }
+    $this->set('field_status', 'accepted');
+    $this->set('field_accepted_at', (new \DateTimeImmutable())->format('Y-m-d'));
+    $this->set('field_accepted_by', $acceptedBy->id());
+  }
+
+  public function isAccepted(): bool {
+    return $this->get('field_status')->value === 'accepted';
+  }
+
+}
+```
+
+### When to Choose Which
+
+| Approach                    | When to Use                                                                                                                                           |
+|-----------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Anemic** (Drupal default) | Simple CRUD, content types with no business logic beyond display                                                                                      |
+| **Rich** (DDD)              | Business rules exist (state machines, calculations, validations that go beyond field constraints), complex entity interactions, external integrations |
+
+You don't need to make every content type rich. A "Basic Page" with a title
+and body is fine as anemic. An "Order" with statuses, deadlines, and approval
+workflows benefits from rich domain methods.
+
+---
+
+## Identity in Drupal
+
+DDD entities are identified by a unique identity that persists over time. Drupal
+already handles this:
+
+| DDD Concept           | Drupal Equivalent    | Notes                                     |
+|-----------------------|----------------------|-------------------------------------------|
+| Entity ID             | `$entity->id()`      | Auto-increment integer (surrogate ID)     |
+| UUID                  | `$entity->uuid()`    | Universally unique, used for content sync |
+| Identity Value Object | Not typically needed | Drupal's built-in ID system is sufficient |
+
+**When you might want typed IDs:** If you're building a complex domain where
+different entity types must never be confused (passing a node ID where a term
+ID is expected), typed ID Value Objects add compile-time safety:
+
+```php
+final readonly class OrderId {
+  private function __construct(private string $id) {}
+
+  public static function fromEntity(OrderInterface $entity): self {
+    return new self((string) $entity->id());
+  }
+
+  public static function fromString(string $id): self {
+    return new self($id);
+  }
+
+  public function toString(): string {
+    return $this->id;
+  }
+
+  public function equals(self $other): bool {
+    return $this->id === $other->id;
+  }
+}
+```
+
+For most Drupal projects, using `string $entityId` with clear parameter naming
+is sufficient. Typed IDs are worth the overhead when you have many entity types
+that interact and type confusion is a real risk.
+
+---
+
+## Making Drupal Entities Rich
+
+### Custom Content Entity with Domain Methods
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\my_module\Entity\Enrollment;
+
+use Drupal\Core\Entity\ContentEntityBase;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Field\BaseFieldDefinition;
+
+#[ContentEntityType(
+  id: 'enrollment',
+  label: new TranslatableMarkup('Enrollment'),
+  // ... handlers, keys, etc.
+)]
+class Enrollment extends ContentEntityBase implements EnrollmentInterface {
+
+  /**
+   * Enroll a student in a course.
+   *
+   * This is a Factory Method — creates a valid enrollment
+   * with all invariants satisfied.
+   *
+   * @throws \Drupal\my_module\Exception\EnrollmentCapacityReachedException
+   */
+  public static function create(
+    array $values = [],
+  ): static {
+    // Use parent::create for Drupal compatibility
+    return parent::create($values);
+  }
+
+  /**
+   * Confirm the enrollment after payment verification.
+   *
+   * @throws \Drupal\my_module\Exception\EnrollmentAlreadyConfirmedException
+   */
+  public function confirm(): void {
+    if ($this->isConfirmed()) {
+      throw new EnrollmentAlreadyConfirmedException(
+        (string) $this->id()
+      );
+    }
+    $this->set('status', 'confirmed');
+    $this->set('confirmed_at', (new \DateTimeImmutable())->format('Y-m-d\TH:i:s'));
+  }
+
+  /**
+   * Cancel the enrollment with a reason.
+   */
+  public function cancel(string $reason): void {
+    if ($this->isCancelled()) {
+      return; // Idempotent
+    }
+    $this->set('status', 'cancelled');
+    $this->set('cancellation_reason', $reason);
+    $this->set('cancelled_at', (new \DateTimeImmutable())->format('Y-m-d\TH:i:s'));
+  }
+
+  public function isConfirmed(): bool {
+    return $this->get('status')->value === 'confirmed';
+  }
+
+  public function isCancelled(): bool {
+    return $this->get('status')->value === 'cancelled';
+  }
+
+  public function isPending(): bool {
+    return $this->get('status')->value === 'pending';
+  }
+
+  /**
+   * Business rule: enrollment can only be confirmed if pending.
+   */
+  public function canBeConfirmed(): bool {
+    return $this->isPending();
+  }
+
+}
+```
+
+### Adapter Pattern for Contrib Entities
+
+You can't modify Drupal core entities (Node, User, Term), but you can wrap
+them with domain interfaces using the Adapter Pattern:
+
+```php
+// Domain interface — what the domain needs
+interface TaggableContentInterface {
+  public function getTags(): array;
+  public function hasTag(string $tagId): bool;
+}
+
+// Adapter — wraps a Drupal Node to implement the domain interface
+class NodeTaggableAdapter implements TaggableContentInterface {
+
+  public function __construct(
+    private readonly NodeInterface $node,
+  ) {}
+
+  public function getTags(): array {
+    if (!$this->node->hasField('field_tags')) {
+      return [];
+    }
+    return array_map(
+      fn($item) => (string) $item->target_id,
+      iterator_to_array($this->node->get('field_tags')),
+    );
+  }
+
+  public function hasTag(string $tagId): bool {
+    return in_array($tagId, $this->getTags(), TRUE);
+  }
+
+}
+```
+
+The Adapter pattern lets you add domain interfaces to entities you don't
+control. The core Node knows nothing about your domain concept of "taggable
+content"; the adapter adds that capability without modifying core.
+
+---
+
+## Aggregates
+
+An Aggregate is a cluster of entities and value objects treated as a single
+unit for data consistency. The **Aggregate Root** is the entry point — all
+access to child entities goes through it.
+
+### Drupal's Natural Aggregates
+
+Drupal already has implicit aggregate patterns:
+
+| Aggregate Root | Children           | Why It's an Aggregate                                                     |
+|----------------|--------------------|---------------------------------------------------------------------------|
+| Node           | Paragraphs         | Paragraphs don't exist independently; they're saved/deleted with the node |
+| Webform        | WebformSubmissions | Submissions belong to a specific form                                     |
+| Menu           | MenuLinkContent    | Links exist within a menu structure                                       |
+| Order          | LineItems          | Line items are meaningless without their order                            |
+
+### When to Model Aggregates Explicitly
+
+Model aggregates explicitly when you need to enforce **business invariants**
+across the root and its children:
+
+```php
+class Forum extends ContentEntityBase implements ForumInterface {
+
+  private const MAX_POSTS_PER_DAY = 50;
+
+  /**
+   * Publish a post within this forum.
+   *
+   * The forum is the Aggregate Root — it controls post creation
+   * and enforces the daily posting limit.
+   */
+  public function publishPost(
+    string $authorId,
+    string $content,
+    PostRepositoryInterface $postRepository,
+  ): Post {
+    if ($this->isClosed()) {
+      throw new ForumClosedException((string) $this->id());
+    }
+
+    $todayCount = $postRepository->countByForumAndDate(
+      (string) $this->id(),
+      new \DateTimeImmutable('today'),
+    );
+
+    if ($todayCount >= self::MAX_POSTS_PER_DAY) {
+      throw new DailyPostLimitReachedException(self::MAX_POSTS_PER_DAY);
+    }
+
+    return Post::create([
+      'forum_id' => $this->id(),
+      'author_id' => $authorId,
+      'content' => $content,
+    ]);
+  }
+
+}
+```
+
+---
+
+## Aggregate Design Rules
+
+From Vaughn Vernon's "Effective Aggregate Design" (cited in DDD in PHP):
+
+### Rule 1: Protect Business Invariants Inside Aggregate Boundaries
+
+An invariant is a business rule that must always be true. The aggregate is
+responsible for enforcing its invariants — no external code should bypass the
+aggregate root.
+
+**In Drupal:** Use entity methods for rules that apply to the entity and its
+children. Use `hook_entity_presave` as a safety net, not as the primary
+enforcement mechanism.
+
+### Rule 2: Design Small Aggregates
+
+Prefer small aggregates — ideally the root entity plus value objects. Large
+aggregates cause performance problems and concurrency conflicts.
+
+**In Drupal:** Don't try to make a single node the aggregate root for dozens of
+referenced entities. If a paragraph references other paragraphs, the "aggregate"
+is the immediate parent-child relationship, not the entire tree.
+
+### Rule 3: Reference Other Aggregates by Identity Only
+
+Don't hold object references to other aggregates. Use IDs.
+
+```php
+// GOOD: reference by ID
+class Order extends ContentEntityBase {
+  // field_customer stores a target_id (integer reference)
+  public function customerId(): string {
+    return (string) $this->get('field_customer')->target_id;
+  }
+}
+
+// BAD: loading the entire customer aggregate
+class Order extends ContentEntityBase {
+  public function customer(): Customer {
+    return $this->get('field_customer')->entity;
+    // This loads the customer, creating a tight coupling
+  }
+}
+```
+
+**Drupal's entity_reference fields already follow this rule** — they store
+target IDs, not loaded objects. The `->entity` property performs lazy loading,
+which is convenient but can lead to unintended coupling. In domain logic, prefer
+using `->target_id` and loading through a repository when needed.
+
+### Rule 4: Use Eventual Consistency Across Aggregates
+
+If a business rule spans two aggregates, use domain events and eventual
+consistency rather than trying to modify both in a single transaction.
+
+```php
+// When an order is placed, update the customer's order count.
+// Don't do this synchronously — use an event.
+
+class Order extends ContentEntityBase {
+  public function place(): void {
+    $this->set('status', 'placed');
+    // The event will be dispatched after save
+    // A listener will update the customer's stats asynchronously
+  }
+}
+
+// In the Application Service:
+$order->place();
+$this->orderRepository->save($order);
+$this->eventDispatcher->dispatch(new OrderWasPlaced($order->id()));
+```
+
+---
+
+## Factories
+
+### Factory Method on Aggregate Root
+
+When creating a child entity requires checking the root's invariants, use
+a factory method on the root:
+
+```php
+class Course extends ContentEntityBase {
+
+  public function createEnrollment(string $studentId): Enrollment {
+    if (!$this->isOpen()) {
+      throw new CourseNotOpenException((string) $this->id());
+    }
+    if ($this->isFull()) {
+      throw new CourseFullException((string) $this->id());
+    }
+    return Enrollment::create([
+      'course_id' => $this->id(),
+      'student_id' => $studentId,
+      'status' => 'pending',
+    ]);
+  }
+
+}
+```
+
+### Factory as Domain Service
+
+When creation involves multiple aggregates or external data, use a mapper
+or factory service:
+
+```php
+final readonly class ExternalProductMapper {
+
+  public function __construct(
+    private ProductRepositoryInterface $products,
+    private CategoryRepositoryInterface $categories,
+  ) {}
+
+  /**
+   * Map a DTO from an external API to a Product entity.
+   *
+   * Creates new or updates existing based on external ID.
+   */
+  public function map(ExternalProductDto $dto): ProductInterface {
+    $existing = $this->products->loadByExternalId($dto->id);
+
+    if ($existing !== NULL) {
+      return $this->updateExisting($existing, $dto);
+    }
+
+    return $this->createNew($dto);
+  }
+
+}
+```
+
+This pattern is common when integrating with external APIs — the mapper
+translates external DTOs to domain entities, handling both creation and updates.
+
+### Test Data Builders
+
+For tests, use the Builder pattern to create entities with sensible defaults:
+
+```php
+class EnrollmentBuilder {
+
+  private string $studentId = 'student-1';
+  private string $courseId = 'course-1';
+  private string $status = 'pending';
+
+  public function withStudent(string $id): self {
+    $clone = clone $this;
+    $clone->studentId = $id;
+    return $clone;
+  }
+
+  public function confirmed(): self {
+    $clone = clone $this;
+    $clone->status = 'confirmed';
+    return $clone;
+  }
+
+  public function build(): Enrollment {
+    return Enrollment::create([
+      'student_id' => $this->studentId,
+      'course_id' => $this->courseId,
+      'status' => $this->status,
+    ]);
+  }
+
+}
+
+// Usage in tests:
+$enrollment = (new EnrollmentBuilder())
+  ->withStudent('student-42')
+  ->confirmed()
+  ->build();
+```
+
+---
+
+## Concurrency and Consistency
+
+Drupal does not provide built-in optimistic or pessimistic locking for content
+entities. When concurrent modifications are a risk, consider these strategies:
+
+### Optimistic Locking (Version Field)
+
+Add a `version` base field that increments on each save. Check it before saving:
+
+```php
+// In the entity's base field definitions:
+$fields['version'] = BaseFieldDefinition::create('integer')
+  ->setLabel(new TranslatableMarkup('Version'))
+  ->setDefaultValue(0);
+
+// In the repository:
+public function save(OrderInterface $order): void {
+  $currentVersion = $order->get('version')->value;
+  // Reload from storage to check version hasn't changed
+  $stored = $this->getStorage()->load($order->id());
+
+  if ($stored && (int) $stored->get('version')->value !== (int) $currentVersion) {
+    throw new OptimisticLockException(
+      sprintf('Order %s was modified concurrently', $order->id())
+    );
+  }
+
+  $order->set('version', $currentVersion + 1);
+  $order->save();
+}
+```
+
+### Pessimistic Locking (Database Lock)
+
+For critical sections, use Drupal's database transaction with a SELECT FOR
+UPDATE:
+
+```php
+$transaction = $this->database->startTransaction();
+try {
+  // Lock the row
+  $this->database->query(
+    'SELECT id FROM {my_entity} WHERE id = :id FOR UPDATE',
+    [':id' => $entityId]
+  );
+
+  $entity = $this->getStorage()->load($entityId);
+  // ... modify ...
+  $entity->save();
+}
+catch (\Exception $e) {
+  $transaction->rollBack();
+  throw $e;
+}
+```
+
+### When to Use
+
+- **Optimistic locking:** Content that is rarely edited concurrently but needs
+  protection (orders, enrollments). Low overhead.
+- **Pessimistic locking:** Critical data with high contention (inventory counts,
+  seat reservations). Higher overhead but guarantees consistency.
+- **Neither:** Content edited by a single admin at a time (most Drupal content).
+  Drupal's built-in "content lock" module may suffice.

--- a/skills/drupal/drupal-ddd/references/repository-pattern.md
+++ b/skills/drupal/drupal-ddd/references/repository-pattern.md
@@ -1,0 +1,594 @@
+# Drupal Repository Design Pattern — Mandatory Architecture
+
+**This is a HARD CONSTRAINT. You MUST follow these rules for ALL entity
+interactions in Drupal modules. There are NO exceptions.**
+
+This project enforces strict separation of concerns through the Repository
+Design Pattern. All entity storage and query logic is encapsulated in
+dedicated repository classes. Controllers, forms, services, event subscribers,
+and plugins NEVER interact with the entity storage layer directly.
+
+---
+
+## Table of Contents
+
+1. [Forbidden Patterns](#forbidden-patterns)
+2. [Required Architecture](#required-architecture)
+3. [Directory Structure](#directory-structure)
+4. [Implementation Guide](#implementation-guide)
+5. [Correct vs Incorrect Examples](#correct-vs-incorrect-examples)
+6. [Decision Checklist](#decision-checklist)
+7. [Abstract Base Class Pattern](#abstract-base-class-pattern)
+8. [Edge Cases and Clarifications](#edge-cases-and-clarifications)
+
+---
+
+## Forbidden Patterns
+
+You **MUST NEVER** do any of the following outside of a Repository class:
+
+| Forbidden Action                                     | Where It Must Not Appear                                                                                               |
+|------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------|
+| Inject `EntityTypeManagerInterface`                  | Controllers, Forms, Services, Event Subscribers, Plugins, Message Handlers                                             |
+| Inject `EntityStorageInterface`                      | Controllers, Forms, Services, Event Subscribers, Plugins, Message Handlers                                             |
+| Call `\Drupal::entityTypeManager()`                  | Anywhere (static calls are always forbidden)                                                                           |
+| Call `\Drupal::entityQuery()`                        | Anywhere outside a Repository                                                                                          |
+| Call `$storage->load()`, `$storage->loadMultiple()`  | Anywhere outside a Repository                                                                                          |
+| Call `$entity->save()`, `$entity->delete()` directly | Anywhere outside a Repository (unless on the entity's own form handler via `$entity->save()` in a content entity form) |
+
+**If you find yourself about to inject `EntityTypeManagerInterface` into a Controller, Form, or Service — STOP. You need
+a Repository.**
+
+---
+
+## Required Architecture
+
+Whenever ANY code needs to interact with entities (load, query, create, save,
+delete), you **MUST**:
+
+1. **Define a Repository Interface** in the domain layer
+2. **Implement the Repository** in the infrastructure layer
+3. **Register it as a service** with an interface alias
+4. **Inject the interface** into the consumer (controller, form, service, etc.)
+
+### Architecture Flow
+
+```
+Consumer (Controller/Form/Service)
+    |
+    |  injects RepositoryInterface (domain contract)
+    v
+RepositoryInterface  <----  defines domain methods (load, query, create...)
+    |
+    |  implemented by
+    v
+ConcreteRepository  ---->  ONLY class allowed to use EntityTypeManagerInterface
+    |
+    |  registered in
+    v
+module.services.yml  ---->  interface alias -> concrete class
+```
+
+---
+
+## Directory Structure
+
+You **MUST** place files according to this layout:
+
+### Custom Module Entities
+
+```
+src/
+├── Entity/
+│   └── {EntityName}/
+│       ├── {EntityName}Interface.php                  # Entity interface
+│       └── {EntityName}RepositoryInterface.php        # Repository contract
+├── Infrastructure/
+│   └── Persistence/
+│       └── Repository/
+│           └── Entity/
+│               ├── Abstract{Module}EntityRepository.php   # Optional base class
+│               └── {EntityName}Repository.php             # Concrete implementation
+```
+
+### Contrib / Third-Party Entity Wrappers
+
+When wrapping entities from contributed modules (User, File, Node, etc.):
+
+```
+src/
+├── Entity/
+│   └── Contrib/
+│       └── {ContribEntity}RepositoryInterface.php     # Repository contract
+├── Infrastructure/
+│   └── Persistence/
+│       └── Repository/
+│           └── Entity/
+│               └── {ContribEntity}Repository.php      # Concrete implementation
+```
+
+---
+
+## Implementation Guide
+
+### Step 1: Define the Repository Interface
+
+Place in `src/Entity/{EntityName}/{EntityName}RepositoryInterface.php` (custom)
+or `src/Entity/Contrib/{Entity}RepositoryInterface.php` (contrib wrapper).
+
+**Rules:**
+
+- Return **strongly-typed** domain objects, never generic `EntityInterface`
+- Use `?TypedReturn` for nullable loads
+- Never expose `EntityStorageInterface` or query objects
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\my_module\Entity\Project;
+
+/**
+ * Repository interface for Project entity operations.
+ */
+interface ProjectRepositoryInterface {
+
+  /**
+   * Load all projects.
+   *
+   * @return array<array-key, \Drupal\my_module\Entity\Project\ProjectInterface>
+   *   The project entities.
+   */
+  public function loadAll(): array;
+
+  /**
+   * Load a single project by ID.
+   *
+   * @param string $entity_id
+   *   The project entity ID.
+   *
+   * @return ?\Drupal\my_module\Entity\Project\ProjectInterface
+   *   The project entity or NULL if not found.
+   */
+  public function load(string $entity_id): ?ProjectInterface;
+
+  /**
+   * Load projects by owner.
+   *
+   * @param string $owner_id
+   *   The owner user ID.
+   *
+   * @return array<array-key, \Drupal\my_module\Entity\Project\ProjectInterface>
+   *   The matching project entities.
+   */
+  public function loadByOwner(string $owner_id): array;
+
+}
+```
+
+### Step 2: Implement the Repository
+
+Place in `src/Infrastructure/Persistence/Repository/Entity/{EntityName}Repository.php`.
+
+**Rules:**
+
+- This is the **ONLY** class that may depend on `EntityTypeManagerInterface`
+- Use `getStorage()` from the abstract base class or inject storage directly
+- All public methods return domain-typed objects
+- Encapsulate `entityQuery` calls inside repository methods
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\my_module\Infrastructure\Persistence\Repository\Entity;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\my_module\Entity\Project\ProjectInterface;
+use Drupal\my_module\Entity\Project\ProjectRepositoryInterface;
+
+class ProjectRepository implements ProjectRepositoryInterface {
+
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+  ) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public function loadAll(): array {
+    /** @var array<array-key, \Drupal\my_module\Entity\Project\ProjectInterface> */
+    return $this->getStorage()->loadMultiple();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function load(string $entity_id): ?ProjectInterface {
+    $entity = $this->getStorage()->load($entity_id);
+    return $entity instanceof ProjectInterface ? $entity : NULL;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function loadByOwner(string $owner_id): array {
+    $ids = $this->getStorage()->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('owner_id', $owner_id)
+      ->execute();
+
+    if (empty($ids)) {
+      return [];
+    }
+
+    /** @var array<array-key, \Drupal\my_module\Entity\Project\ProjectInterface> */
+    return $this->getStorage()->loadMultiple($ids);
+  }
+
+  private function getStorage(): \Drupal\Core\Entity\EntityStorageInterface {
+    return $this->entityTypeManager->getStorage('my_module_project');
+  }
+
+}
+```
+
+### Step 3: Register the Service
+
+In `my_module.services.yml`:
+
+```yaml
+services:
+    # Concrete repository (autowired)
+    Drupal\my_module\Infrastructure\Persistence\Repository\Entity\ProjectRepository: ~
+
+    # Interface alias — consumers inject the INTERFACE, resolved to the concrete class
+    Drupal\my_module\Entity\Project\ProjectRepositoryInterface:
+        '@Drupal\my_module\Infrastructure\Persistence\Repository\Entity\ProjectRepository'
+```
+
+For repositories needing constructor arguments (e.g., entity type ID):
+
+```yaml
+services:
+    Drupal\my_module\Infrastructure\Persistence\Repository\Entity\ProjectRepository:
+        arguments:
+            $entityTypeId: 'my_module_project'
+
+    Drupal\my_module\Entity\Project\ProjectRepositoryInterface:
+        '@Drupal\my_module\Infrastructure\Persistence\Repository\Entity\ProjectRepository'
+```
+
+### Step 4: Inject Into Consumers
+
+Controllers, forms, services, and message handlers inject the **interface**:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\my_module\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\my_module\Entity\Project\ProjectRepositoryInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+class ProjectController extends ControllerBase {
+
+  public function __construct(
+    private readonly ProjectRepositoryInterface $projectRepository,
+  ) {}
+
+  public function list(): JsonResponse {
+    $projects = $this->projectRepository->loadAll();
+    // ... build response
+    return new JsonResponse($data);
+  }
+
+  public function detail(string $project_id): JsonResponse {
+    $project = $this->projectRepository->load($project_id);
+    if ($project === NULL) {
+      throw new NotFoundHttpException();
+    }
+    // ... build response
+    return new JsonResponse($data);
+  }
+
+}
+```
+
+---
+
+## Correct vs Incorrect Examples
+
+### Scenario: A controller needs to load a Tenant entity by ID
+
+#### INCORRECT — Do NOT generate this
+
+```php
+// WRONG: Injecting EntityTypeManagerInterface directly into a controller.
+class TenantController extends ControllerBase {
+
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager, // FORBIDDEN
+  ) {}
+
+  public function view(string $tenant_id): array {
+    $tenant = $this->entityTypeManager
+      ->getStorage('sf_ai_tenant')  // Direct storage access
+      ->load($tenant_id);
+    // ...
+  }
+
+}
+```
+
+**Why it is wrong:**
+
+- The controller now knows about storage internals (entity type ID, storage API)
+- Business logic and persistence are coupled
+- Cannot be unit-tested without mocking the entire entity subsystem
+- Violates the Single Responsibility Principle
+
+#### CORRECT — Generate this instead
+
+```php
+// RIGHT: Inject the repository interface.
+class TenantController extends ControllerBase {
+
+  public function __construct(
+    private readonly TenantRepositoryInterface $tenantRepository, // Domain contract
+  ) {}
+
+  public function view(string $tenant_id): array {
+    $tenant = $this->tenantRepository->load($tenant_id); // Clean, typed, testable
+    // ...
+  }
+
+}
+```
+
+**Why it is correct:**
+
+- Controller depends on a domain interface, not infrastructure
+- Storage logic is encapsulated in `TenantRepository`
+- Easily unit-testable with a mock/stub of `TenantRepositoryInterface`
+- Adding new query methods requires only updating the repository, never the consumer
+
+---
+
+### Scenario: A form needs to create a new Webpage entity
+
+#### INCORRECT
+
+```php
+class WebpageCreateForm extends FormBase {
+
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager, // FORBIDDEN
+  ) {}
+
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
+    $storage = $this->entityTypeManager->getStorage('sf_ai_webpage');
+    $webpage = $storage->create([
+      'uri' => $form_state->getValue('uri'),
+    ]);
+    $webpage->save(); // Direct save outside repository
+  }
+
+}
+```
+
+#### CORRECT
+
+```php
+class WebpageCreateForm extends FormBase {
+
+  public function __construct(
+    private readonly WebpageRepositoryInterface $webpageRepository,
+  ) {}
+
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
+    $this->webpageRepository->create(
+      new WebpageDTO(url: $form_state->getValue('uri')),
+      $knowledgeBase,
+      WebpageSyncFrequency::Daily,
+    ); // Repository handles creation, validation, and persistence
+  }
+
+}
+```
+
+---
+
+### Scenario: A service needs to query entities with conditions
+
+#### INCORRECT
+
+```php
+class WebpageSyncService {
+
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager, // FORBIDDEN
+  ) {}
+
+  public function findStaleWebpages(): array {
+    $ids = $this->entityTypeManager->getStorage('sf_ai_webpage')
+      ->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('last_sync', strtotime('-1 day'), '<')
+      ->execute();
+
+    return $this->entityTypeManager->getStorage('sf_ai_webpage')
+      ->loadMultiple($ids);
+  }
+
+}
+```
+
+#### CORRECT
+
+```php
+// 1. Add the method to the repository interface:
+interface WebpageRepositoryInterface {
+  public function loadStaleWebpages(\DateTimeInterface $since): array;
+}
+
+// 2. Implement in the repository:
+class WebpageRepository implements WebpageRepositoryInterface {
+
+  public function loadStaleWebpages(\DateTimeInterface $since): array {
+    $ids = $this->getStorage()->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('last_sync', $since->getTimestamp(), '<')
+      ->execute();
+
+    return empty($ids) ? [] : $this->getStorage()->loadMultiple($ids);
+  }
+
+}
+
+// 3. Inject the interface into the service:
+class WebpageSyncService {
+
+  public function __construct(
+    private readonly WebpageRepositoryInterface $webpageRepository,
+  ) {}
+
+  public function findStaleWebpages(): array {
+    return $this->webpageRepository->loadStaleWebpages(
+      new \DateTimeImmutable('-1 day'),
+    );
+  }
+
+}
+```
+
+---
+
+## Decision Checklist
+
+Before generating any entity-related code, ask yourself:
+
+| Question                                                          | If YES                                                               |
+|-------------------------------------------------------------------|----------------------------------------------------------------------|
+| Does this class need to load an entity?                           | Inject a `RepositoryInterface`                                       |
+| Does this class need to query entities by conditions?             | Add a method to the `RepositoryInterface`, implement in `Repository` |
+| Does this class need to create/save/delete entities?              | Add a method to the `RepositoryInterface`, implement in `Repository` |
+| Is the entity from a contrib module (User, File, Node, etc.)?     | Create a wrapper repository under `Entity/Contrib/`                  |
+| Am I about to type `EntityTypeManagerInterface` in a constructor? | **STOP.** You need a Repository instead.                             |
+
+---
+
+## Abstract Base Class Pattern
+
+When a module has multiple custom entity repositories sharing common behavior,
+use an abstract base class:
+
+```php
+abstract class AbstractModuleEntityRepository implements ModuleEntityRepositoryInterface {
+
+  public function __construct(
+    private readonly string $entityTypeId,
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+  ) {}
+
+  protected function getStorage(): EntityStorageInterface {
+    return $this->entityTypeManager->getStorage($this->entityTypeId);
+  }
+
+}
+```
+
+Concrete repositories extend the base class **and implement a domain-specific
+interface**. All public methods **MUST** return strongly-typed domain objects:
+
+```php
+class ProjectRepository extends AbstractModuleEntityRepository
+  implements ProjectRepositoryInterface {
+
+  public function __construct(
+    string $entityTypeId,
+    EntityTypeManagerInterface $entityTypeManager,
+  ) {
+    parent::__construct($entityTypeId, $entityTypeManager);
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * @return array<array-key, \Drupal\my_module\Entity\Project\ProjectInterface>
+   */
+  public function loadAll(): array {
+    /** @var array<array-key, \Drupal\my_module\Entity\Project\ProjectInterface> */
+    return $this->getStorage()->loadMultiple();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function load(string $entity_id): ?ProjectInterface {
+    $entity = $this->getStorage()->load($entity_id);
+    return $entity instanceof ProjectInterface ? $entity : NULL;
+  }
+
+  /**
+   * @return array<array-key, \Drupal\my_module\Entity\Project\ProjectInterface>
+   */
+  public function loadByOwner(string $owner_id): array {
+    $ids = $this->getStorage()->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('owner_id', $owner_id)
+      ->execute();
+
+    if (empty($ids)) {
+      return [];
+    }
+
+    /** @var array<array-key, \Drupal\my_module\Entity\Project\ProjectInterface> */
+    return $this->getStorage()->loadMultiple($ids);
+  }
+
+}
+```
+
+The corresponding interface defines the full domain contract with typed returns:
+
+```php
+interface ProjectRepositoryInterface extends ModuleEntityRepositoryInterface {
+
+  /**
+   * @return array<array-key, \Drupal\my_module\Entity\Project\ProjectInterface>
+   */
+  public function loadAll(): array;
+
+  public function load(string $entity_id): ?ProjectInterface;
+
+  /**
+   * @return array<array-key, \Drupal\my_module\Entity\Project\ProjectInterface>
+   */
+  public function loadByOwner(string $owner_id): array;
+
+}
+```
+
+---
+
+## Edge Cases and Clarifications
+
+- **Entity forms** (extending `ContentEntityForm` or `EntityForm`): The form's
+  built-in `$this->entity->save()` in `save()` is acceptable — the form
+  system itself manages the entity lifecycle. You do NOT need a repository
+  for the entity form's own save operation.
+- **Entity list builders**: `EntityListBuilder` receives storage by design
+  from Drupal core. This is acceptable within the list builder class only.
+- **Hook implementations**: If a hook receives an entity parameter, operating
+  on that entity directly is fine. But if the hook needs to LOAD additional
+  entities, use a repository.
+- **Migrations**: Migration plugins may use `EntityTypeManagerInterface`
+  directly, as they are infrastructure-level operations.
+- **Tests**: Test classes may use `EntityTypeManagerInterface` for test setup
+  and assertions. Production code must still use repositories.

--- a/skills/drupal/drupal-ddd/references/services-and-events.md
+++ b/skills/drupal/drupal-ddd/references/services-and-events.md
@@ -1,0 +1,524 @@
+# Services and Domain Events in Drupal
+
+## Table of Contents
+
+1. [The Three Service Types](#the-three-service-types)
+2. [Domain Services](#domain-services)
+3. [Application Services](#application-services)
+4. [Domain Events](#domain-events)
+5. [The Anemic Model Trap](#the-anemic-model-trap)
+6. [Transactions](#transactions)
+
+---
+
+## The Three Service Types
+
+DDD distinguishes three kinds of services. Understanding the difference is
+critical for keeping logic in the right place.
+
+| Type                       | Lives In             | Purpose                                            | Example                                      |
+|----------------------------|----------------------|----------------------------------------------------|----------------------------------------------|
+| **Domain Service**         | Domain layer         | Business logic that doesn't fit an entity          | `EnrollmentEligibilityChecker`               |
+| **Application Service**    | Application layer    | Orchestrates use cases, coordinates domain objects | `PlaceOrderService`, form submit handlers    |
+| **Infrastructure Service** | Infrastructure layer | Technical concerns (HTTP, email, file I/O)         | `PaymentGatewayClient`, `OAuthTokenProvider` |
+
+**The rule:** Domain Services contain business rules. Application Services
+coordinate flow. Infrastructure Services talk to the outside world.
+
+---
+
+## Domain Services
+
+A Domain Service handles business logic that doesn't naturally belong to a
+single entity. It is **stateless** — it doesn't remember anything between calls.
+
+### When to Use
+
+- The operation involves **multiple entities** (e.g., transferring money between
+  two accounts)
+- The operation requires **domain knowledge** but no single entity owns it
+  (e.g., checking eligibility for enrollment based on multiple criteria)
+- The logic would make the entity **too complex** or require dependencies the
+  entity shouldn't have
+
+### Implementation Pattern
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\my_module\Domain;
+
+/**
+ * Checks if a student is eligible for enrollment in a course.
+ *
+ * This is a Domain Service because the eligibility check involves
+ * multiple domain objects and business rules that don't belong to
+ * any single entity.
+ */
+final readonly class EnrollmentEligibilityChecker {
+
+  /**
+   * Check enrollment eligibility.
+   *
+   * @param array<string, mixed> $studentData
+   *   Student data including prerequisites.
+   * @param array<string, mixed> $courseData
+   *   Course data including capacity and requirements.
+   *
+   * @return bool
+   *   TRUE if the student is eligible.
+   */
+  public function isEligible(
+    array $studentData,
+    array $courseData,
+  ): bool {
+    // Business rules:
+    // 1. Student has completed prerequisites
+    // 2. Course has available capacity
+    // 3. Enrollment window is open
+    // 4. Student is not already enrolled
+    return $this->hasPrerequisites($studentData, $courseData)
+      && $this->hasCapacity($courseData)
+      && $this->isWithinEnrollmentWindow($courseData);
+  }
+
+  private function hasPrerequisites(array $student, array $course): bool {
+    // ... domain logic
+    return TRUE;
+  }
+
+  private function hasCapacity(array $course): bool {
+    return ($course['enrolled_count'] ?? 0) < ($course['max_capacity'] ?? PHP_INT_MAX);
+  }
+
+  private function isWithinEnrollmentWindow(array $course): bool {
+    // ... domain logic
+    return TRUE;
+  }
+
+}
+```
+
+### Domain Service vs Infrastructure Service
+
+When a domain operation depends on external systems, split it:
+
+```php
+// Domain layer: interface
+namespace Drupal\my_module\Domain;
+
+interface PasswordHashingInterface {
+  public function hash(string $plainPassword): string;
+  public function verify(string $plainPassword, string $hash): bool;
+}
+
+// Infrastructure layer: implementation
+namespace Drupal\my_module\Infrastructure;
+
+final readonly class BcryptPasswordHashing implements PasswordHashingInterface {
+  public function hash(string $plainPassword): string {
+    return password_hash($plainPassword, PASSWORD_BCRYPT);
+  }
+  public function verify(string $plainPassword, string $hash): bool {
+    return password_verify($plainPassword, $hash);
+  }
+}
+```
+
+The domain interface expresses what the domain needs. The infrastructure
+implementation handles how it's done. Wire them in `services.yml`:
+
+```yaml
+Drupal\my_module\Infrastructure\BcryptPasswordHashing: ~
+Drupal\my_module\Domain\PasswordHashingInterface:
+  alias: Drupal\my_module\Infrastructure\BcryptPasswordHashing
+```
+
+### Typical Domain Service Examples
+
+- **`SiteSettings`** — wraps config access with domain-meaningful method names
+  (`getMaxItemsPerPage()`, `isRegistrationOpen()`)
+- **`PricingCalculator`** — computes prices applying discounts, taxes, and
+  currency conversion rules
+- **`ShippingCostEstimator`** — determines shipping cost based on weight,
+  destination, and carrier rules
+
+---
+
+## Application Services
+
+Application Services are thin orchestrators. They coordinate the execution
+of a use case without containing business logic themselves.
+
+### The Formula
+
+Every application service follows the same pattern:
+
+1. **Accept a request** (DTO with primitives, not domain objects)
+2. **Load aggregates** from repositories
+3. **Call domain methods** on the aggregates
+4. **Persist changes** via repositories
+5. **Dispatch events** if needed
+6. **Return a response** (DTO, not domain entities)
+
+### Implementation Pattern
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\my_module\Service;
+
+use Drupal\my_module\Entity\Enrollment\EnrollmentRepositoryInterface;
+use Drupal\my_module\Entity\Contrib\NodeRepositoryInterface;
+use Drupal\my_module\Domain\EnrollmentEligibilityChecker;
+use Drupal\my_module\Event\StudentWasEnrolled;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * Application Service: orchestrates student enrollment.
+ *
+ * This service does NOT contain business logic — it coordinates
+ * domain objects and infrastructure.
+ */
+final readonly class EnrollStudentService {
+
+  public function __construct(
+    private EnrollmentRepositoryInterface $enrollments,
+    private NodeRepositoryInterface $courses,
+    private EnrollmentEligibilityChecker $eligibilityChecker,
+    private EventDispatcherInterface $eventDispatcher,
+    #[Autowire(service: 'logger.channel.my_module')]
+    private LoggerInterface $logger,
+  ) {}
+
+  /**
+   * Enroll a student in a course.
+   *
+   * @param string $studentId
+   *   The student user ID.
+   * @param string $courseId
+   *   The course entity ID.
+   *
+   * @return \Drupal\my_module\Entity\ValueObject\EnrollmentOutcome
+   *   The enrollment outcome.
+   */
+  public function execute(string $studentId, string $courseId): EnrollmentOutcome {
+    // 1. Load aggregates
+    $course = $this->courses->load($courseId);
+    if ($course === NULL) {
+      return EnrollmentOutcome::failed('Course not found');
+    }
+
+    // 2. Check domain rules (via Domain Service)
+    if (!$this->eligibilityChecker->isEligible($studentId, $course)) {
+      return EnrollmentOutcome::failed('Student not eligible');
+    }
+
+    // 3. Create enrollment (domain method on aggregate root)
+    $enrollment = $course->createEnrollment($studentId);
+
+    // 4. Persist
+    $this->enrollments->save($enrollment);
+
+    // 5. Dispatch domain event
+    $this->eventDispatcher->dispatch(
+      new StudentWasEnrolled($studentId, $courseId),
+    );
+
+    // 6. Return result
+    $this->logger->info('Student {student} enrolled in course {course}', [
+      'student' => $studentId,
+      'course' => $courseId,
+    ]);
+
+    return EnrollmentOutcome::enrolled((string) $enrollment->id());
+  }
+
+}
+```
+
+### Application Services in Drupal's Architecture
+
+In Drupal, application services sit between the framework layer (controllers,
+forms, Drush commands) and the domain:
+
+```
+Controller / Form / Drush Command
+  → calls Application Service (thin orchestrator)
+    → uses Repository (load/save)
+    → calls Domain methods (business logic)
+    → dispatches Events (side effects)
+    → returns DTO (no entities leak out)
+```
+
+**Rules:**
+- Application Services accept **primitives or DTOs** (not entities)
+- Application Services return **DTOs or Value Objects** (not entities)
+- Application Services manage **transactions** (see below)
+- Application Services do NOT contain `if/else` business logic — that goes
+  in domain methods or domain services
+- Application Services are the right place to handle **logging** and
+  **event dispatching**
+
+### When Is a Dedicated Application Service Worth It?
+
+- The same operation is triggered from multiple places (form, REST, Drush)
+- The operation involves multiple repositories or external services
+- The operation has side effects (events, notifications)
+- You want to unit test the orchestration independently from the framework
+
+If the operation is simple (load one entity, change one field, save), a form
+submit handler calling a repository directly is fine.
+
+---
+
+## Domain Events
+
+A Domain Event records that something significant happened in the domain. It
+is **immutable** — a fact about the past that cannot be changed.
+
+### Naming Convention
+
+Domain Events are named as **past-tense verbs**:
+- `StudentWasEnrolled`
+- `OrderWasPlaced`
+- `PaymentWasReceived`
+- `InventoryWasReplenished`
+
+### Event Class
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\my_module\Event;
+
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * Dispatched when a student enrolls in a course.
+ */
+final class StudentWasEnrolled extends Event {
+
+  public function __construct(
+    public readonly string $studentId,
+    public readonly string $courseId,
+    public readonly \DateTimeImmutable $occurredOn = new \DateTimeImmutable(),
+  ) {}
+
+}
+```
+
+### Event Subscriber
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\my_module\EventSubscriber;
+
+use Drupal\my_module\Event\StudentWasEnrolled;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Reacts to enrollment events.
+ */
+final class SendEnrollmentConfirmation implements EventSubscriberInterface {
+
+  public function __construct(
+    private readonly MailManagerInterface $mailManager,
+  ) {}
+
+  public static function getSubscribedEvents(): array {
+    return [
+      StudentWasEnrolled::class => 'onStudentEnrolled',
+    ];
+  }
+
+  public function onStudentEnrolled(StudentWasEnrolled $event): void {
+    // Send confirmation email — this is a side effect, not domain logic
+    $this->mailManager->mail(
+      'my_module',
+      'enrollment_confirmation',
+      $this->getStudentEmail($event->studentId),
+      'en',
+      ['course_id' => $event->courseId],
+    );
+  }
+
+}
+```
+
+### Domain Events vs Drupal Hooks
+
+|                  | Drupal Hooks                                                      | Domain Events                                 |
+|------------------|-------------------------------------------------------------------|-----------------------------------------------|
+| **Coupling**     | Tight (hook implementations know about internal entity structure) | Loose (events carry only what listeners need) |
+| **Semantics**    | Technical (`hook_entity_insert`)                                  | Domain (`StudentWasEnrolled`)                 |
+| **Cross-module** | Any module can implement any hook                                 | Events are dispatched by the owning module    |
+| **Async**        | Always synchronous                                                | Can be async (via Symfony Messenger)          |
+| **Testing**      | Requires Drupal bootstrap                                         | Can test dispatch + handling independently    |
+
+**Use hooks when:**
+- You need to alter Drupal's built-in behavior (form alter, entity view, etc.)
+- The reaction is tightly coupled to Drupal's lifecycle (presave, insert, delete)
+
+**Use Domain Events when:**
+- The side effect is in a different Bounded Context
+- You want to decouple modules
+- The reaction can happen asynchronously
+- You need an audit trail of what happened
+- You want to test the event dispatch independently
+
+### Async Domain Events with Symfony Messenger
+
+For operations that can tolerate delay, dispatch a message instead:
+
+```php
+// Message class (immutable, serializable)
+final readonly class SyncOrderToExternalSystem {
+  public function __construct(
+    public string $orderId,
+    public string $targetSystem,
+  ) {}
+}
+
+// Handler (processes the message asynchronously)
+#[AsMessageHandler]
+final readonly class SyncOrderHandler {
+  public function __construct(
+    private OrderRepositoryInterface $orders,
+    private ExternalClient $client,
+  ) {}
+
+  public function __invoke(SyncOrderToExternalSystem $message): void {
+    $order = $this->orders->load($message->orderId);
+    $this->client->sync($order, $message->targetSystem);
+  }
+}
+```
+
+---
+
+## The Anemic Model Trap
+
+The Anemic Domain Model anti-pattern is the most common DDD pitfall in Drupal
+because Drupal's architecture naturally pushes logic away from entities.
+
+### How to Detect It
+
+| Signal                                                                   | What It Means                     |
+|--------------------------------------------------------------------------|-----------------------------------|
+| Entity has only getters/setters, no business methods                     | Logic is elsewhere                |
+| `hook_entity_presave` contains `if ($entity->bundle() === 'X')` branches | Business rules leaked into hooks  |
+| A "god service" orchestrates dozens of field operations                  | Service is doing the entity's job |
+| Domain events are dispatched from services, never from entities          | Entities are passive data bags    |
+
+### How to Fix It
+
+1. **Identify business operations** — look at your hooks and services for
+   `$entity->set()` calls surrounded by business logic
+2. **Move them to entity methods** — create named methods that express
+   the intent (`$order->accept()`, `$enrollment->confirm()`)
+3. **Keep hooks thin** — hooks should delegate to entity methods or services
+4. **Test entity methods** — since they contain the logic, they need tests
+
+```php
+// BEFORE: Logic in a hook
+function my_module_entity_presave(EntityInterface $entity): void {
+  if ($entity instanceof OrderInterface && $entity->isNew()) {
+    $entity->set('field_order_number', OrderNumberGenerator::next());
+    $entity->set('field_created_by', \Drupal::currentUser()->id());
+    $entity->set('field_status', 'draft');
+  }
+}
+
+// AFTER: Logic on the entity
+class Order extends ContentEntityBase implements OrderInterface {
+  public static function createDraft(
+    string $orderNumber,
+    string $createdBy,
+  ): static {
+    return static::create([
+      'field_order_number' => $orderNumber,
+      'field_created_by' => $createdBy,
+      'field_status' => 'draft',
+    ]);
+  }
+}
+
+// Application Service calls the factory method:
+$order = Order::createDraft(
+  $this->orderNumberGenerator->next(),
+  $currentUser->id(),
+);
+$this->orderRepository->save($order);
+```
+
+### The Pragmatic Middle Ground
+
+Not every entity needs to be a rich domain model. The decision tree:
+
+- **No business logic** (basic page, simple content) → Anemic is fine
+- **Some validation** (field constraints, required fields) → Drupal's built-in
+  validation is sufficient
+- **Business rules** (state transitions, calculations, cross-field invariants) →
+  Rich entity methods
+- **Complex orchestration** (multi-entity, external systems) → Rich entity
+  methods + Domain Services + Application Services
+
+---
+
+## Transactions
+
+### Who Manages Transactions?
+
+The Application Service layer owns transaction boundaries. Domain objects
+and repositories should not start or commit transactions — they operate within
+a transaction managed by their caller.
+
+### Drupal's Transaction Support
+
+```php
+// In an Application Service:
+public function transferFunds(string $fromId, string $toId, Money $amount): void {
+  $transaction = $this->database->startTransaction();
+  try {
+    $from = $this->accountRepository->load($fromId);
+    $to = $this->accountRepository->load($toId);
+
+    $from->debit($amount);
+    $to->credit($amount);
+
+    $this->accountRepository->save($from);
+    $this->accountRepository->save($to);
+
+    // Transaction commits when $transaction goes out of scope
+  }
+  catch (\Exception $e) {
+    $transaction->rollBack();
+    throw $e;
+  }
+}
+```
+
+**Drupal's transaction model:** Transactions in Drupal auto-commit when the
+transaction object goes out of scope. Call `$transaction->rollBack()` explicitly
+on failure. Nested transactions use savepoints.
+
+### When Transactions Matter
+
+- Multiple entities modified in a single operation (both must succeed or fail)
+- Financial or accounting operations
+- Operations where partial completion would leave data inconsistent
+
+For single-entity saves, Drupal's built-in `$entity->save()` is already
+atomic — no manual transaction needed.

--- a/skills/drupal/drupal-ddd/references/value-objects.md
+++ b/skills/drupal/drupal-ddd/references/value-objects.md
@@ -1,0 +1,456 @@
+# Value Objects in Drupal
+
+## Table of Contents
+
+1. [What Is a Value Object](#what-is-a-value-object)
+2. [When to Use Value Objects in Drupal](#when-to-use-value-objects-in-drupal)
+3. [Anatomy of a Value Object](#anatomy-of-a-value-object)
+4. [Persistence Strategies](#persistence-strategies)
+5. [Common Value Object Patterns](#common-value-object-patterns)
+6. [Testing Value Objects](#testing-value-objects)
+
+---
+
+## What Is a Value Object
+
+A Value Object is an immutable object defined by its attributes rather than
+an identity. Two Value Objects with the same data are considered equal — like
+two $10 bills are interchangeable regardless of serial number.
+
+Six characteristics (from Eric Evans / DDD in PHP):
+
+1. **Describes** a thing — it measures, quantifies, or describes a domain concept
+2. **Immutable** — once created, it cannot be changed
+3. **Conceptual Whole** — groups related attributes into a single unit
+4. **Value Equality** — compared by content, not reference
+5. **Replaceable** — changed by replacing the whole object
+6. **Side-Effect-Free** — operations return new instances, never modify `$this`
+
+## When to Use Value Objects in Drupal
+
+Use a Value Object when you find yourself:
+
+- Passing related primitives together (`$amount` + `$currency`, `$start` + `$end`)
+- Validating the same format in multiple places (email, URL, ISO code)
+- Performing calculations that involve multiple fields (money arithmetic)
+- Wanting to prevent invalid states (negative prices, malformed codes)
+
+**Skip Value Objects when:**
+- The value is a simple scalar with no validation beyond Drupal's field constraints
+- The value is only used in one place with no behavior
+- You're modeling a Drupal config form with simple text/boolean fields
+
+### Drupal Fields vs PHP Value Objects
+
+Drupal fields already provide storage-level typing and constraints. PHP Value
+Objects add **domain-level** guarantees on top:
+
+| Concern               | Drupal Field                | PHP Value Object             |
+|-----------------------|-----------------------------|------------------------------|
+| Storage type          | Yes (varchar, int, etc.)    | No (in-memory only)          |
+| Required/optional     | Yes                         | Yes (via constructor)        |
+| Format validation     | Limited (maxlength, etc.)   | Full (regex, business rules) |
+| Behavior (methods)    | No                          | Yes                          |
+| Immutability          | No (fields are mutable)     | Yes                          |
+| Testable in isolation | No (needs Drupal bootstrap) | Yes (pure PHP)               |
+
+The two work together: Value Objects enforce rules in your domain code, and
+Drupal fields handle persistence.
+
+---
+
+## Anatomy of a Value Object
+
+### Basic Pattern
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\my_module\Entity\ValueObject;
+
+/**
+ * Represents a postal code with country-specific validation.
+ *
+ * Immutable. Self-validating. Two PostalCode objects with
+ * the same code and country are considered equal.
+ */
+final readonly class PostalCode {
+
+  /**
+   * Private constructor — use the static factory method.
+   *
+   * @param string $code
+   *   The postal code.
+   * @param string $countryCode
+   *   The ISO 3166-1 alpha-2 country code.
+   */
+  private function __construct(
+    private string $code,
+    private string $countryCode,
+  ) {}
+
+  /**
+   * Create a PostalCode for a given country.
+   *
+   * @param string $code
+   *   The postal code string.
+   * @param string $countryCode
+   *   Two-letter ISO country code (e.g. "US", "IT", "DE").
+   *
+   * @return self
+   *   A new PostalCode instance.
+   *
+   * @throws \InvalidArgumentException
+   *   If the code does not match the country format.
+   */
+  public static function fromString(string $code, string $countryCode): self {
+    $countryCode = strtoupper($countryCode);
+    $pattern = match ($countryCode) {
+      'US' => '/^\d{5}(-\d{4})?$/',
+      'IT' => '/^\d{5}$/',
+      'DE' => '/^\d{5}$/',
+      'GB' => '/^[A-Z]{1,2}\d[A-Z\d]?\s?\d[A-Z]{2}$/i',
+      default => '/^.{2,10}$/',
+    };
+    if (!preg_match($pattern, $code)) {
+      throw new \InvalidArgumentException(
+        sprintf('"%s" is not a valid postal code for %s', $code, $countryCode)
+      );
+    }
+    return new self($code, $countryCode);
+  }
+
+  public function code(): string {
+    return $this->code;
+  }
+
+  public function countryCode(): string {
+    return $this->countryCode;
+  }
+
+  public function toString(): string {
+    return sprintf('%s (%s)', $this->code, $this->countryCode);
+  }
+
+  /**
+   * Value equality — two PostalCodes are equal if they represent
+   * the same code in the same country.
+   */
+  public function equals(self $other): bool {
+    return $this->code === $other->code
+      && $this->countryCode === $other->countryCode;
+  }
+
+  public function __toString(): string {
+    return $this->toString();
+  }
+
+}
+```
+
+### Key Design Decisions
+
+**Private constructor + static factory methods:** This forces callers to go
+through validation. You cannot create an invalid PostalCode.
+
+**`final readonly class`:** PHP 8.2+ makes immutability automatic. All
+properties are readonly, the class cannot be extended, and there are no setters.
+
+**`equals()` method:** Value Objects compare by content, not by reference.
+Always provide an `equals()` method for domain comparisons.
+
+**Named constructors:** Use `fromString()`, `fromArray()`, `of()` etc.
+to support different input formats while keeping validation centralized.
+
+---
+
+## Persistence Strategies
+
+Value Objects live in PHP memory. To persist them, convert at the repository
+boundary.
+
+### Strategy 1: Embedded Value (Recommended for Queryable Data)
+
+Flatten the Value Object into multiple Drupal field columns.
+
+```php
+// In the repository: entity → Value Object
+public function loadProduct(string $id): Product {
+  $entity = $this->getStorage()->load($id);
+  $price = Money::of(
+    (float) $entity->get('field_price_amount')->value,
+    Currency::fromCode($entity->get('field_price_currency')->value),
+  );
+  return new Product($entity, $price);
+}
+
+// In the repository: Value Object → entity
+public function save(Product $product): void {
+  $entity = $product->entity();
+  $entity->set('field_price_amount', $product->price()->amount());
+  $entity->set('field_price_currency', $product->price()->currency()->code());
+  $entity->save();
+}
+```
+
+**Drupal mapping:** Each component maps to a separate Drupal field or field
+property. Queryable via entity queries.
+
+### Strategy 2: Serialized LOB (For Complex, Non-Queryable Data)
+
+Store the Value Object as JSON in a single text field.
+
+```php
+// Serialize
+$entity->set('field_metadata', json_encode($metadata->toArray()));
+
+// Deserialize
+$data = json_decode($entity->get('field_metadata')->value, TRUE);
+$metadata = Metadata::fromArray($data);
+```
+
+**When to use:** Complex nested structures that you never query by (audit data,
+configuration blobs, external API response snapshots).
+
+**Caution:** You cannot query individual properties. Schema changes require
+migration of stored JSON.
+
+### Strategy 3: Custom Field Type (For Reusable Domain Types)
+
+Create a Drupal field type that wraps a Value Object. This is the most
+Drupal-native approach but requires more boilerplate.
+
+```php
+#[FieldType(
+  id: 'money',
+  label: new TranslatableMarkup('Money'),
+  description: new TranslatableMarkup('Stores a monetary value.'),
+)]
+class MoneyFieldType extends FieldItemBase {
+
+  public static function schema(FieldStorageDefinitionInterface $definition): array {
+    return [
+      'columns' => [
+        'amount' => ['type' => 'numeric', 'precision' => 19, 'scale' => 4],
+        'currency' => ['type' => 'varchar', 'length' => 3],
+      ],
+    ];
+  }
+
+  public function toMoney(): Money {
+    return Money::of(
+      (float) $this->get('amount')->getValue(),
+      Currency::fromCode($this->get('currency')->getValue()),
+    );
+  }
+
+}
+```
+
+**When to use:** The Value Object is used across multiple entity types and
+benefits from having a reusable field type with widget and formatter.
+
+---
+
+## Common Value Object Patterns
+
+### Money (Amount + Currency)
+
+```php
+final readonly class Money {
+
+  private function __construct(
+    private float $amount,
+    private Currency $currency,
+  ) {}
+
+  public static function of(float $amount, Currency $currency): self {
+    return new self($amount, $currency);
+  }
+
+  public function add(self $other): self {
+    $this->guardSameCurrency($other);
+    return new self($this->amount + $other->amount, $this->currency);
+  }
+
+  private function guardSameCurrency(self $other): void {
+    if (!$this->currency->equals($other->currency)) {
+      throw new CurrencyMismatchException($this->currency, $other->currency);
+    }
+  }
+
+}
+```
+
+### EmailAddress
+
+```php
+final readonly class EmailAddress {
+
+  private function __construct(
+    private string $address,
+  ) {}
+
+  public static function fromString(string $address): self {
+    if (!filter_var($address, FILTER_VALIDATE_EMAIL)) {
+      throw new \InvalidArgumentException(
+        sprintf('"%s" is not a valid email', $address)
+      );
+    }
+    return new self(strtolower($address));
+  }
+
+  public function equals(self $other): bool {
+    return $this->address === $other->address;
+  }
+
+  public function domain(): string {
+    return substr($this->address, strpos($this->address, '@') + 1);
+  }
+
+}
+```
+
+### DateRange
+
+```php
+final readonly class DateRange {
+
+  private function __construct(
+    private \DateTimeImmutable $start,
+    private \DateTimeImmutable $end,
+  ) {}
+
+  public static function between(
+    \DateTimeImmutable $start,
+    \DateTimeImmutable $end,
+  ): self {
+    if ($start >= $end) {
+      throw new \InvalidArgumentException('Start must be before end');
+    }
+    return new self($start, $end);
+  }
+
+  public function contains(\DateTimeImmutable $date): bool {
+    return $date >= $this->start && $date <= $this->end;
+  }
+
+  public function overlaps(self $other): bool {
+    return $this->start < $other->end && $other->start < $this->end;
+  }
+
+  public function durationInDays(): int {
+    return (int) $this->start->diff($this->end)->days;
+  }
+
+}
+```
+
+### OperationOutcome (Result Pattern)
+
+A tri-state result value object — useful for operations that can succeed,
+fail, or be skipped:
+
+```php
+final readonly class OperationOutcome {
+
+  private function __construct(
+    private string $status,
+    private ?\Throwable $exception = NULL,
+    private bool $retryable = FALSE,
+  ) {}
+
+  public static function succeeded(): self {
+    return new self('succeeded');
+  }
+
+  public static function failed(\Throwable $e, bool $retryable = FALSE): self {
+    return new self('failed', $e, $retryable);
+  }
+
+  public static function skipped(): self {
+    return new self('skipped');
+  }
+
+  public function isSucceeded(): bool { return $this->status === 'succeeded'; }
+  public function isFailed(): bool { return $this->status === 'failed'; }
+  public function isRetryable(): bool { return $this->retryable; }
+
+}
+```
+
+---
+
+## Testing Value Objects
+
+Value Objects are the easiest DDD building block to test — they are pure PHP
+with no dependencies.
+
+```php
+class PostalCodeTest extends TestCase {
+
+  public function testCreatesValidUsPostalCode(): void {
+    $code = PostalCode::fromString('90210', 'US');
+    $this->assertSame('90210', $code->code());
+    $this->assertSame('US', $code->countryCode());
+  }
+
+  public function testCreatesValidUsZipPlusFour(): void {
+    $code = PostalCode::fromString('90210-1234', 'US');
+    $this->assertSame('90210-1234', $code->code());
+  }
+
+  public function testRejectsInvalidUsPostalCode(): void {
+    $this->expectException(\InvalidArgumentException::class);
+    PostalCode::fromString('ABCDE', 'US');
+  }
+
+  public function testValueEquality(): void {
+    $a = PostalCode::fromString('90210', 'US');
+    $b = PostalCode::fromString('90210', 'US');
+    $c = PostalCode::fromString('10001', 'US');
+    $this->assertTrue($a->equals($b));
+    $this->assertFalse($a->equals($c));
+  }
+
+  public function testDifferentCountriesMeansNotEqual(): void {
+    $us = PostalCode::fromString('12345', 'US');
+    $de = PostalCode::fromString('12345', 'DE');
+    $this->assertFalse($us->equals($de));
+  }
+
+  public function testImmutability(): void {
+    $code = PostalCode::fromString('90210', 'US');
+    $reflection = new \ReflectionClass($code);
+    $this->assertTrue($reflection->isReadOnly());
+  }
+
+}
+```
+
+### Testing Persistence Conversion
+
+```php
+class MoneyPersistenceTest extends KernelTestBase {
+
+  public function testRoundTrip(): void {
+    $original = Money::of(99.99, Currency::fromCode('EUR'));
+
+    // Simulate saving
+    $entity = Node::create(['type' => 'product']);
+    $entity->set('field_price_amount', $original->amount());
+    $entity->set('field_price_currency', $original->currency()->code());
+
+    // Simulate loading
+    $loaded = Money::of(
+      (float) $entity->get('field_price_amount')->value,
+      Currency::fromCode($entity->get('field_price_currency')->value),
+    );
+
+    $this->assertTrue($original->equals($loaded));
+  }
+
+}
+```

--- a/skills/drupal/drupal-module-development/SKILL.md
+++ b/skills/drupal/drupal-module-development/SKILL.md
@@ -1,0 +1,302 @@
+---
+name: drupal-module-development
+description: >-
+  How to develop custom Drupal 11 modules on SparkFabrik's Firestarter platform.
+  Covers module scaffolding, hook implementations, and best practices for custom
+  functionality. Use this skill whenever building custom features that can't be
+  achieved with contrib modules or configuration alone — whether it's a simple
+  hook_form_alter or a complex integration with external APIs.
+  Always follow Drupal coding standards and the config-first workflow for any
+  structural changes.
+---
+
+ALWAYS CLEAR CACHES AFTER ANY CODE CHANGE! Use `drush cr` or `drush cache:rebuild` to ensure you see the latest code in action.
+
+ALWAYS RUN A FULL QA CHECK WHEN IMPLEMENTATION IS COMPLETE! Use `make drupal-qa` to run all quality checks and fix any
+issues, even those not introduced by your code. For implementation that impacts the web UI (both admin and frontend),
+check if they are working as expected in a real browser and that no new errors appear in the logs.
+
+# Code Style and Standards
+Adhere to Drupal coding standards (PSR-12 with Drupal extensions). Use Coder and PHPCS for enforcement.
+
+- **PHP**:
+    - Indentation: 2 spaces (no tabs)
+    - Line length: ≤ 80 characters
+    - Naming: CamelCase classes/methods, snake_case variables/functions
+    - Always use braces; prefer early returns
+    - Full PHPDoc blocks with `@param`, `@return`, `@throws`
+
+- **YAML**: 2-space indentation, lowercase keys
+- **Twig**: `{{ }}` for output, `{% %}` for logic; always escape with `|e`
+
+Case conventions:
+* Classes: PascalCase (e.g., `MyModuleService`)
+* Methods: camelCase (e.g., `getConfigValue()`)
+* Properties: camelCase (e.g., `$configFactory`)
+* Functions: lower_case (e.g., `my_module_helper()`)
+* Variables: lower_case (e.g., `$my_variable`)
+
+**Reject any code that fails Drupal Coder sniffs.**
+
+# Drupal Development Patterns
+
+## Attributes
+- **use PHP8 attributes** for plugin definitions, hooks, and other metadata
+
+## Services & Dependency Injection
+- **Create services** in `modulename.services.yml` file for reusable logic
+- **Use dependency injection** to inject services into controllers, forms, and plugins
+- **Core services** like `@current_user`, `@entity_type.manager`, `@database` are available
+- **Best practice**: Avoid static `\Drupal::` calls in favor of dependency injection
+- **Service discovery**: Use `drush eval "print_r(\Drupal::getContainer()->getServiceIds());"` to see available services
+- **Location**: Place service classes in `src/` directory with proper namespace
+
+### Dependency Injection Optimization
+
+**Core Principle: Keep Constructors Lightweight (Lazy Initialization)**
+
+In Drupal, service constructors should be strictly limited to assigning injected dependencies to class properties. With PHP 8+, this is best achieved using **constructor property promotion**.
+
+**The Rule:** Do not fetch configuration, compute values, or instantiate complex objects (like HTTP clients or external API wrappers) directly inside the `__construct()` method.
+
+**Why it matters:**
+* **Preserves Lazy Loading:** Service containers often instantiate services just to inject them into other services, even if they aren't used in that specific request. Doing "real work" in the constructor forces unnecessary processing and memory allocation.
+* **Improves Testability:** Keeping constructors simple isolates logic failures to specific method executions rather than failing during the initial mock/setup phase of a unit test.
+
+**The Solution:**
+Use PHP 8 constructor property promotion to inject services (like `ConfigFactory`), and use a private/protected **getter method** with memoization to instantiate complex objects only when they are first explicitly requested.
+
+**Code Example:**
+
+```php
+// ❌ BAD: Doing work in the constructor
+public function __construct(
+  protected ConfigFactoryInterface $configFactory,
+  protected ?ApiClient $apiClient = null,
+) {
+  // Forces config load and allocation every time the service is built
+  $config = $this->configFactory->get('my.settings'); 
+  $this->apiClient = new ApiClient($config->get('api_key'));
+}
+
+// ✅ GOOD: Lazy loading + PHP 8 Promoted Properties
+class MyService {
+  // The client itself is not promoted, as it is not injected
+  protected ?ApiClient $apiClient = null;
+
+  public function __construct(
+    // Dependencies are promoted and automatically assigned
+    protected ConfigFactoryInterface $configFactory,
+  ) {} // Constructor body is completely empty!
+
+  protected function getApiClient(): ApiClient {
+    // Memoization: Build it only once, and only if requested
+    if ($this->apiClient === null) {
+      $config = $this->configFactory->get('my.settings');
+      $this->apiClient = new ApiClient($config->get('api_key'));
+    }
+    return $this->apiClient;
+  }
+}
+```
+
+### Autoconfiguration
+Automatically tags services based on the interfaces they implement. Registered in CoreServiceProvider (since Drupal 10.2):
+
+* EventSubscriberInterface -> event_subscriber
+* LoggerAwareInterface -> logger_aware
+* PreWarmableInterface -> cache_prewarmable
+* ModuleUninstallValidatorInterface -> module_install.uninstall_validator
+* MediaLibraryOpenerInterface -> media_library.opener
+
+### Autowiring
+When enabled, the container resolves constructor dependencies automatically by matching type hints to FQCN-aliased services. Enable it globally:
+
+```yml
+services:
+  _defaults:
+    autoconfigure: true
+    autowire: true
+  Drupal\my_module\MyService: ~   # tilde = no extra config needed
+```
+
+Always use the FQCN as the service ID for your own services. This allows autowiring to work seamlessly without needing to specify service names. Add an alias only if you need to reference the service by a different name.
+
+If multiple services implement the same interface (e.g. LoggerInterface), the container throws an exception. Use the `#[Autowire]` attribute:
+
+```php
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Psr\Log\LoggerInterface;
+class MyService {
+  public function __construct(
+    #[Autowire(service: 'logger.channel.my_module')]
+    private readonly LoggerInterface $logger,
+  ) {}
+}
+```
+
+Drupal service container does not support binding arguments by name with `bind`, never use it. Always rely on type hints and autowiring for dependencies.
+
+Any class implementing `Symfony\Component\DependencyInjection\ContainerInterface\ContainerInjectionInterface` can use `Drupal\Core\DependencyInjection\AutowireTrait` trait for autowiring.
+
+#### Autowiring in Controllers (Drupal 10.2+)
+`ControllerBase` already ships with `AutowireTrait`. Don't use the static create() factory, but use constructor injection directly:
+
+```php
+class MyController extends ControllerBase {
+  public function __construct(
+    private readonly MyService $myService,
+  ) {}
+}
+```
+
+#### Autowiring in Hook classes (Drupal 11.1+)
+Hook classes are automatically registered as autowired services:
+
+```php
+namespace Drupal\my_module\Hook;
+class MyModuleHooks {
+  public function __construct(
+    protected readonly EntityTypeManagerInterface $entityTypeManager,
+  ) {}
+  #[Hook('entity_presave')]
+  public function entityPresave(EntityInterface $entity): void { ... }
+}
+```
+
+## Entity API & Queries
+- **Entity queries**: Use entity queries for database operations instead of raw SQL
+- **Query conditions**: Chain multiple conditions with `->condition()`, `->sort()`, `->range()`
+- **Field access**: Use entity field API instead of direct property access
+- **Performance**: Use entity query cache tags and contexts for optimal caching
+
+### Repository Pattern (MANDATORY)
+
+This project enforces the **Repository Design Pattern** for ALL entity interactions.
+Controllers, forms, services, event subscribers, and plugins NEVER interact with
+entity storage directly — no `EntityTypeManagerInterface` injection, no `\Drupal::entityQuery()`,
+no direct `$entity->save()` or `$entity->delete()` outside of repository classes.
+
+**Whenever you need to load, query, create, save, or delete entities, load the
+`drupal-ddd` skill and read its `references/repository-pattern.md`** — it covers
+interface definition, concrete implementation, service registration, directory
+structure, correct/incorrect examples, and edge cases. The DDD skill also covers
+Value Objects, Aggregates, Domain Services, Domain Events, and other patterns for
+structuring complex business logic in Drupal modules.
+
+## Plugin System
+- **Plugin types**: Blocks, field formatters, field widgets, menu links, and more
+- **Plugin discovery**: Use annotation-based discovery in docblocks
+- **Plugin configuration**: Define plugin ID, label, and other metadata in annotations
+- **Plugin base classes**: Extend appropriate base classes (BlockBase, FormatterBase, etc.)
+- **Plugin placement**: Place plugins in `src/Plugin/Type/` directory structure
+- **Derivative plugins**: Use for creating multiple plugins from one definition
+
+## Hooks
+- **Hook implementation**: Implement hooks as methods in the `Hook` namespace of your module
+- **Hook attributes**: Use `#[Hook('hook_name')]` attribute to define which hook the method implements
+- **Hook naming**: Give hooks descriptive names that indicate their purpose (`addFieldToNodeForm()`, `alterMenuLinks()`, etc.)
+- **Hook parameters**: Use type hints and proper parameter documentation
+- **Hook order**: Hooks fire in module weight order (lowest first)
+- **Best practice**: Keep hook implementations focused and use services for complex logic
+
+## Forms API
+- **Form classes**: Extend `FormBase` for simple forms or `ConfigFormBase` for configuration forms
+- **Form structure**: Use render array structure with `#type`, `#title`, `#description` properties
+- **Form validation**: Implement `validateForm()` method for custom validation
+- **Form submission**: Implement `submitForm()` method for processing form data
+- **Form elements**: Use proper form element types (textfield, select, checkbox, etc.)
+- **AJAX forms**: Add `#ajax` property to form elements for dynamic behavior
+- **Form caching**: Forms are automatically cached with CSRF protection
+
+## Routes & Controllers
+- **Routing file**: Define routes in `modulename.routing.yml` with path, defaults, and requirements
+- **Controllers**: ALWAYS create controller classes extending `ControllerBase` in `src/Controller/`. ControllerBase already includes the AutowireTrait for dependency injection. ControllerBase provides common helper methods and access to core services, you MUST use them.
+- **Route parameters**: Use `{parameter}` placeholders in paths and inject into controller methods
+- **Access control**: Implement `_permission`, `_role`, or custom access callbacks
+- **Route naming**: Use `modulename.action` naming convention for clarity
+- **Controller injection**: Use constructor injection for dependencies
+- **Return values**: Return render arrays or Symfony Response objects
+
+# Security & Performance Guidelines
+
+## Security Requirements
+- **Always sanitize user input**: Use `#plain_text` for untrusted content
+- **CSRF protection**: Include `#token` for forms with side effects
+- **Permissions**: Implement proper access checks and route requirements
+- **SQL Injection**: Use Entity Query or proper parameter binding
+- **XSS Prevention**: Always use `|e` filter in Twig, `#markup` for trusted HTML only
+- **File uploads**: Validate file types and sizes
+- **Database credentials**: Never commit credentials to version control
+
+## Performance Best Practices
+- **Render caching**: Always add `#cache` array to render arrays with appropriate `tags` and `contexts`
+- **Cache tags**: Use entity-based tags like `['node:123']` or list-based tags like `['node_list']`
+- **Cache contexts**: Apply user-specific contexts like `['user.roles']` for personalized content
+- **Lazy loading**: Use `#lazy_builder` for expensive operations that can be loaded separately
+- **Placeholder strategy**: Set `#create_placeholder: TRUE` for lazy builders to improve initial page load
+- **Cache max-age**: Set appropriate `max-age` values based on content freshness requirements
+- **Avoid premature optimization**: Profile first, then optimize based on actual bottlenecks
+- **Database queries**: Use entity queries instead of raw SQL for better caching and security
+- **Entity loading**: Load multiple entities at once when possible for better performance
+
+## Caching Strategies
+- **Render cache**: Cache complex markup with proper tags/contexts
+- **Dynamic page cache**: Configure for anonymous users
+- **Internal page cache**: Enable for authenticated users
+- **Entity cache**: Leverage core entity caching
+- **Redis/Memcache**: Configure for distributed caching
+
+# Development Workflow
+
+## Project Structure
+- **Modules** → `modules/custom/<module_name>`
+- **Themes** → `themes/custom/<theme_name>`
+- **Configuration** → Export with `drush config:export`
+- **Profiles** → `profiles/custom/<profile_name>`
+
+## Essential Development Commands
+```bash
+# Cache management
+drush cr                    # Clear all caches
+drush cache:rebuild         # Alternative cache clear
+
+# Configuration management
+drush config:export         # Export configuration
+drush config:import         # Import configuration
+drush config:diff           # Compare config with directory
+
+# Database operations
+drush sql:dump              # Export database
+drush sql:cli               # Access database CLI
+drush updatedb              # Run database updates
+```
+
+## Debugging & Troubleshooting
+
+**When debugging issues, read `references/debugging-tools.md`** for the full
+drush command reference — logs, cache debugging, config debugging, module/theme
+debugging, database/entity debugging, performance profiling, and common
+troubleshooting recipes.
+
+Key quick-reference:
+- Logs: `docker compose logs -f drupal-php` (Monolog to stdout, no watchdog)
+- Cache rebuild: `drush cr`
+- Config inspect: `drush config:get <name>`
+- Interactive PHP: `drush php` or `drush php:eval "code"`
+
+# Testing & Quality Assurance
+
+**When writing or running tests, read `references/testing-qa.md`** for PHPUnit
+framework details, test types (Unit, Kernel, Functional), and code quality tool
+usage.
+
+Key essentials:
+- Run all QA checks: `make drupal-qa`
+- Run individual tools: `make drupal-qa phpcs`, `make drupal-qa phpstan`, etc.
+- **NEVER** run QA tools from `bin/` directly — always use `make drupal-qa <tool>`
+
+# Advanced Development Patterns
+
+**When implementing Batch API, Symfony Messenger, or AJAX forms, read
+`references/advanced-patterns.md`** for detailed guidance on each pattern.

--- a/skills/drupal/drupal-module-development/references/advanced-patterns.md
+++ b/skills/drupal/drupal-module-development/references/advanced-patterns.md
@@ -1,0 +1,41 @@
+# Advanced Development Patterns
+
+## Table of Contents
+
+1. [Batch API for Long Operations](#batch-api-for-long-operations)
+2. [Symfony Messenger for Background Processing](#symfony-messenger-for-background-processing)
+3. [AJAX Forms](#ajax-forms)
+
+---
+
+## Batch API for Long Operations
+
+- **Purpose**: Process large datasets without PHP timeout issues
+- **Use cases**: Data migration, bulk updates, file processing, API calls
+- **Batch structure**: Create associative array with title, operations, and finished callback
+- **Operations**: Array of callable methods and their arguments
+- **Progress tracking**: Automatically shows progress bar to users
+- **Error handling**: Implement proper exception handling in batch operations
+- **User experience**: Provides real-time feedback during long operations
+- **Memory management**: Processes data in chunks to prevent memory exhaustion
+
+## Symfony Messenger for Background Processing
+
+- **Purpose**: Process tasks in the background without blocking user interaction
+- **Message dispatch**: Use `$messageBus->dispatch(new MyMessage($data))` to queue tasks
+- **Processing**: Write a message handler class that implements `MessageHandlerInterface` to process messages
+- **Worker**: Run `php bin/console messenger:consume` to start processing messages from the queue
+- **Logging**: Implement proper logging for queue processing monitoring
+
+## AJAX Forms
+
+- **Trigger elements**: Add `#ajax` property to form elements (select, checkbox, button)
+- **Callback method**: Reference callback method using `::methodName` syntax
+- **Wrapper element**: Specify target element ID for AJAX response replacement
+- **Response format**: Return form element or render array from callback
+- **Event types**: Use 'change', 'click', 'blur' events as needed
+- **Progress indicator**: Automatically shows loading indicator during AJAX requests
+- **Error handling**: Implement try-catch blocks in AJAX callbacks
+- **Form state**: Use `$form_state->getTriggeringElement()` to identify trigger
+- **Multiple triggers**: Can have multiple AJAX elements in same form
+- **Dynamic forms**: Update form options, show/hide fields based on user input

--- a/skills/drupal/drupal-module-development/references/debugging-tools.md
+++ b/skills/drupal/drupal-module-development/references/debugging-tools.md
@@ -1,0 +1,125 @@
+# Debugging Tools & Troubleshooting
+
+## Table of Contents
+
+1. [Logs](#logs)
+2. [Core Debugging & Information Commands](#core-debugging--information-commands)
+3. [Cache Debugging](#cache-debugging)
+4. [Configuration Debugging](#configuration-debugging)
+5. [Module/Theming Debugging](#moduletheming-debugging)
+6. [Database & Entity Debugging](#database--entity-debugging)
+7. [Development & Error Reproduction](#development--error-reproduction)
+8. [Performance & Query Debugging](#performance--query-debugging)
+9. [Performance Profiling](#performance-profiling)
+10. [Troubleshooting Common Issues](#troubleshooting-common-issues)
+
+---
+
+## Logs
+
+Logs are exported using the Monolog module to the standard output of the container. Monolog configuration is defined in `src/drupal/web/sites/default/pkg_drupal.services.yml`.
+Drupal watchdog module IS NOT installed in this project.
+
+Use `docker compose logs -f drupal-php` to view logs in real time.
+
+## Core Debugging & Information Commands
+
+| Command                                                               | Purpose                                                                | Why it's useful for debugging                                                                                                                         |
+|-----------------------------------------------------------------------|------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `drush status`                                                        | Shows Drupal root, site path, database connection, Drush version, etc. | Quickly verify that Drush is pointing to the correct site and DB is connected.                                                                        |
+| `drush core-status`                                                   | Same as above but more detailed in newer versions.                     |                                                                                                                                                       |
+
+## Cache Debugging
+
+| Command                            | Purpose                                                                         |
+|------------------------------------|---------------------------------------------------------------------------------|
+| `drush cache:rebuild` / `drush cr` | Rebuilds all caches (equivalent to "drush cc all" in D7).                       |
+| `drush cache:get <bin>:<cid>`      | Retrieve a specific cache item (e.g., `drush cache:get config:core.extension`). |
+| `drush cache:clear <bin>`          | Clear only one cache bin (render, config, discovery, etc.).                     |
+
+## Configuration Debugging
+
+| Command                                 | Purpose                                                                   |
+|-----------------------------------------|---------------------------------------------------------------------------|
+| `drush config:get <name>`               | Show a single configuration value (e.g., `drush config:get system.site`). |
+| `drush config:set <name> <key> <value>` | Temporarily change a config value without using the UI.                   |
+| `drush config:export` / `drush cex`     | Export active config to sync directory.                                   |
+| `drush config:import` / `drush cim`     | Import config -- very useful to test if config issues cause errors.       |
+| `drush config:delete <name>`            | Remove a config object (helps when orphaned config causes fatal errors).  |
+
+## Module/Theming Debugging
+
+| Command                                                                                                                    | Purpose                                                        |
+|----------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------|
+| `drush pm:list --type=module --status=enabled`                                                                             | List enabled modules.                                          |
+| `drush pm:enable <module>` / `drush en <module>`                                                                           | Enable a module.                                               |
+| `drush pm:uninstall <module>` / `drush puninstall <module>`                                                                | Fully uninstall a module (removes config and data).            |
+| `drush pm:uninstall` without arguments: interactive mode is excellent for disabling suspected problematic modules quickly. |                                                                |
+| `drush theme:debug` (Drupal 9.4+)                                                                                          | Lists all theme suggestions for a given route or render array. |
+
+## Database & Entity Debugging
+
+| Command                 | Purpose                                                                                                                                                            |
+|-------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `drush sql:connect`     | Outputs the CLI command to connect to the DB (useful for manual queries).                                                                                          |
+| `drush sql:query`       | Run arbitrary SQL.                                                                                                                                                 |
+| `drush entity:info`     | Show entity type definitions (useful when entity schema errors occur).                                                                                             |
+| `drush php`             | Opens an interactive PHP shell with Drupal bootstrapped (like `drush php:eval`).                                                                                   |
+| `drush php:eval "code"` | Execute arbitrary PHP code in Drupal context (great for quick debugging). Example: `drush php:eval "dpm(\Drupal::state()->get('system.cron_last'));"` (with Devel) |
+
+## Development & Error Reproduction
+
+| Command                                                                  | Purpose                                                                 |
+|--------------------------------------------------------------------------|-------------------------------------------------------------------------|
+| `drush php:eval "var_dump(function_exists('my_problematic_function'));"` | Quick test if a function exists or what it returns.                     |
+| `drush state:edit` / `drush state:get/set/delete`                        | Inspect or override Drupal state values (often used by broken modules). |
+| `drush variable:get/set/delete` (D7 only)                                | Legacy equivalent of state commands.                                    |
+| `drush twig:debug`                                                       | Turn Twig debugging on/off and verify template suggestions.             |
+| `drush eval` (alias of php:eval)                                         | Same as above.                                                          |
+
+## Performance & Query Debugging
+
+| Command                                                                      | Purpose                                                           |
+|------------------------------------------------------------------------------|-------------------------------------------------------------------|
+| `drush sql:query --db-prefix`                                                | See queries with table prefixes expanded (helps reading raw SQL). |
+| Enable Devel + `drush kint` or `dpm()` in code: instant output in terminal.  |                                                                   |
+
+## Performance Profiling
+
+```bash
+# Performance analysis
+drush cr                     # Rebuild caches
+drush sql:query "EXPLAIN ANALYZE SELECT ..."  # Query analysis
+drush site:status           # System status check
+
+# Use Webprofiler module for detailed profiling
+# Access at http://127.0.0.1:8888/admin/config/development/devel/webprofiler
+```
+
+## Troubleshooting Common Issues
+
+### Performance Issues
+
+```bash
+# Identify slow queries
+drush sql:query "SELECT * FROM watchdog WHERE type = 'php' ORDER BY wid DESC LIMIT 10"
+
+# Check cache settings
+drush config:get system.performance
+```
+
+### Module/Theme Development Issues
+
+```bash
+drush cr
+
+# Service not found
+drush config:get core.extension
+
+# Twig template not loading
+drush cr
+
+# Cron issues
+drush cron
+drush watchdog:show --type=cron
+```

--- a/skills/drupal/drupal-module-development/references/testing-qa.md
+++ b/skills/drupal/drupal-module-development/references/testing-qa.md
@@ -1,0 +1,88 @@
+# Testing & Quality Assurance
+
+## Table of Contents
+
+1. [PHPUnit Testing Framework](#phpunit-testing-framework)
+2. [Test Types](#test-types)
+3. [Code Quality Tools](#code-quality-tools)
+
+---
+
+## PHPUnit Testing Framework
+
+Aim for >= 80% code coverage. Drupal provides multiple test types:
+
+```bash
+# Run all tests with coverage
+phpunit -v --coverage-html coverage/
+
+# Run specific test suites
+phpunit --testsuite unit          # Unit tests (fast)
+phpunit --testsuite kernel         # Kernel tests
+phpunit --testsuite functional     # Functional tests (slower)
+phpunit --testsuite javascript     # JavaScript tests
+
+# Run specific tests
+phpunit --filter MyModuleUnitTest
+phpunit modules/custom/my_module/tests/src/Unit/
+```
+
+## Test Types
+
+### Unit Tests (fastest)
+
+- **Purpose**: Test individual classes and methods in isolation
+- **Base class**: Extend `UnitTestCase` from `Drupal\Tests\UnitTestCase`
+- **Speed**: Fastest test type, no Drupal bootstrap required
+- **Isolation**: Test one piece of functionality at a time
+- **Dependencies**: Mock external dependencies and services
+- **Location**: Place in `tests/src/Unit/` directory
+- **Use cases**: Service logic calculations, utility functions, data transformations
+- **Best practices**: Keep tests small, focused, and deterministic
+
+### Kernel Tests (with database)
+
+- **Purpose**: Test Drupal interactions with minimal Drupal environment
+- **Base class**: Extend `KernelTestBase` from `Drupal\KernelTests\KernelTestBase`
+- **Environment**: Partial Drupal bootstrap with in-memory database
+- **Modules**: Declare required modules in `$modules` static property
+- **Database**: Uses SQLite in-memory database for speed
+- **Location**: Place in `tests/src/Kernel/` directory
+- **Use cases**: Entity CRUD operations, configuration validation, service registration
+- **Setup**: Install modules and configuration in `setUp()` method
+
+### Functional Tests (with browser)
+
+- **Purpose**: Test complete user interactions through browser simulation
+- **Base class**: Extend `BrowserTestBase` from `Drupal\Tests\BrowserTestBase`
+- **Environment**: Full Drupal bootstrap with real browser
+- **Speed**: Slowest test type, full page loads required
+- **Theme**: Set `$defaultTheme` property (usually 'stark' or 'claro')
+- **Location**: Place in `tests/src/Functional/` directory
+- **Use cases**: Form submissions, page access, user permissions, JavaScript interactions
+- **Browser simulation**: Uses Goutte/ChromeDriver for browser automation
+- **Assertions**: Use `$this->assertSession()` for web assertions
+
+## Code Quality Tools
+
+```bash
+make drupal-qa  # Run all quality checks (linting, coding standards, etc.)
+```
+
+You can run individual tools to speed up the process:
+
+```bash
+# Run PHPCS only
+make drupal-qa phpcs
+
+# Run CSpell only
+make drupal-qa cspell
+
+# Run PHPMD only
+make drupal-qa phpmd
+
+# Run PHPStan only
+make drupal-qa phpstan
+```
+
+**NEVER** run individual tools from bin directory! **ALWAYS** use the `make drupal-qa <tool>` command to ensure proper environment variables and configuration are applied.

--- a/skills/drupal/drupal-php-standards/SKILL.md
+++ b/skills/drupal/drupal-php-standards/SKILL.md
@@ -1,0 +1,869 @@
+---
+name: drupal-php-standards
+description: >
+  Write PHP code that passes all QA checks (PHPCS, PHPStan level 8, PHPMD, CSpell) on the first try.
+  This project enforces strict coding standards via GrumPHP with zero-tolerance thresholds.
+  Use this skill whenever you are writing or modifying PHP code in a Drupal module, theme, or
+  any .php/.module/.install/.inc/.theme file. Even for small changes — a one-line hook, a new
+  service method, a migration plugin — always apply these rules. The goal is to never trigger a
+  QA failure at commit time. If you are *fixing* existing QA failures after the fact, use the
+  drupal-qa skill instead; this skill is about getting it right from the start.
+---
+
+# Writing QA-Compliant PHP for Drupal 11
+
+This project runs four PHP quality tools via GrumPHP with **zero tolerance** — a single
+violation from any tool blocks the commit. This skill ensures you write code that passes
+all four checks on the first attempt.
+
+The four tools and what they care about:
+
+| Tool        | Focus                                | Level                                                        |
+|-------------|--------------------------------------|--------------------------------------------------------------|
+| **PHPCS**   | Code style and formatting            | Drupal + PreviousNextDrupal + SparkFabrikCS + DrupalPractice |
+| **PHPStan** | Static type analysis                 | Level 8 (strictest) with `phpstan-strict-rules`              |
+| **PHPMD**   | Code complexity and design           | All rulesets except cleancode                                |
+| **CSpell**  | Spelling in identifiers and comments | en-US + Italian dictionary                                   |
+
+## File Boilerplate
+
+Every PHP file must start with:
+
+```php
+<?php
+
+declare(strict_types=1);
+```
+
+No space around `=` in the declare statement. This is enforced by
+`SlevomatCodingStandard.TypeHints.DeclareStrictTypes`.
+
+## Formatting Rules
+
+### Indentation and Line Length
+
+- 2-space indentation (no tabs)
+- Lines should stay under 80 characters where practical
+
+### Trailing Commas
+
+Always use trailing commas in multi-line function calls, declarations, and arrays.
+This is enforced by `SlevomatCodingStandard.Functions.RequireTrailingCommaInCall`
+and `RequireTrailingCommaInDeclaration`.
+
+```php
+// Correct
+$this->entityTypeManager->getStorage(
+    'node',
+);
+
+public function __construct(
+    private readonly Connection $database,
+    private readonly LoggerInterface $logger,
+) {}
+
+$items = [
+    'first',
+    'second',
+];
+```
+
+### Blank Line Before return and continue
+
+Always insert a blank line before `return` and `continue` when they follow
+a statement. This is the single custom sniff from SparkFabrikCS.
+
+```php
+public function process(string $value): string {
+    $result = \trim($value);
+
+    return $result;  // blank line above
+}
+```
+
+No blank line is needed when `return` is the very first statement in a block:
+
+```php
+if ($value === NULL) {
+    return '';  // first statement — no blank line needed
+}
+```
+
+### No Blank Line After Opening Brace
+
+```php
+public function example(): void {
+    $x = 1;  // no blank line between brace and first statement
+}
+```
+
+### Multi-Line Constructor Signatures
+
+When a constructor exceeds 80 characters, break it across multiple lines
+(enforced by `SlevomatCodingStandard.Classes.RequireMultiLineMethodSignature`
+with `minLineLength: 80` targeting `__construct`).
+
+### Use Statement Ordering
+
+`use` import statements must be sorted alphabetically.
+Enforced by `SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses`.
+
+### Fully Qualified Global Functions
+
+Always prefix global PHP functions with a backslash: `\array_map()`, `\count()`,
+`\sprintf()`, `\trim()`, `\is_array()`, `\str_starts_with()`, etc.
+Enforced by `SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalFunctions`.
+
+### Null-Safe Operator
+
+Use the null-safe operator `?->` instead of null-check-then-call patterns.
+Enforced by `SlevomatCodingStandard.ControlStructures.RequireNullSafeObjectOperator`.
+
+```php
+// Wrong
+$value = $entity !== NULL ? $entity->label() : NULL;
+
+// Right
+$value = $entity?->label();
+```
+
+### TRUE, FALSE and NULL must be uppercase
+
+Enforced by `Generic.PHP.UpperCaseConstant.Found`.
+
+```php
+// Wrong
+if ($value === null) {
+    return false;
+}
+// Right
+if ($value === NULL) {
+    return FALSE;
+}
+```
+
+### Static Closures
+
+Closures that don't reference `$this` must be declared `static`.
+Enforced by `SlevomatCodingStandard.Functions.StaticClosure`.
+
+```php
+// Wrong
+$mapped = \array_map(function ($item) {
+    return $item->id();
+}, $items);
+
+// Right
+$mapped = \array_map(static function ($item) {
+    return $item->id();
+}, $items);
+```
+
+## Class Structure Ordering
+
+The project enforces a strict member ordering via
+`SlevomatCodingStandard.Classes.ClassStructure`. Every class must arrange
+its members in this sequence:
+
+1. **Trait `use` statements**
+2. **Enum cases** (if applicable)
+3. **Public constants**
+4. **Other constants** (protected, private)
+5. **Properties** (all visibilities)
+6. **Constructor**
+7. **PHPUnit setUp / @before methods** (in test classes)
+8. **All public methods**
+9. **All other methods** (protected, private)
+10. **Magic methods** (`__toString`, `__get`, etc.)
+
+Getting this wrong produces a `ClassStructure` error. Typical mistake:
+putting a private helper method above a public method.
+
+## Return Type Hints
+
+Return type hints are required on all methods and functions.
+Enforced by `SlevomatCodingStandard.TypeHints.ReturnTypeHint`.
+
+## Documentation Rules
+
+The project **disables** most mandatory docblock rules. You do NOT need:
+- Class docblocks (`Drupal.Commenting.ClassComment.Missing` is off)
+- Function docblocks (`Drupal.Commenting.FunctionComment.Missing` is off)
+- File docblocks (`Drupal.Commenting.FileComment.Missing` is off)
+- Variable comments (`Drupal.Commenting.VariableComment.Missing` is off)
+
+Add docblocks when they provide genuine value — complex parameters, non-obvious
+return types, usage examples. Avoid useless `{@inheritdoc}` comments (flagged
+by `SlevomatCodingStandard.Commenting.UselessInheritDocComment`).
+
+When you do write docblocks for methods that **override a parent**, use `@phpstan-param`
+and `@phpstan-return` instead of `@param`/`@return` to avoid conflicting with the
+parent's documentation. See the PHPStan section for details.
+
+## Blacklisted Debug Statements
+
+The pre-commit hook blocks these patterns via `git_blacklist`:
+
+- `var_dump(...)` / `die(...)` / `dpm(...)` / `error_log(...)`
+- `var_export(...)` / `print_r($var)` (though `print_r($var, TRUE)` is allowed)
+- `console.log(...)`
+
+Never leave debug statements in committed code.
+
+---
+
+## PHPStan Level 8
+
+PHPStan runs at level 8 with `phpstan-strict-rules`, `phpstan-deprecation-rules`,
+and `mglaman/phpstan-drupal`. This means:
+
+- All parameters and return types must be fully typed
+- No `mixed` leaking without explicit handling
+- Deprecated API usage is flagged
+- Drupal-specific patterns (services, hooks, entity API) are understood
+
+### Type Annotations for Inherited Methods
+
+When overriding a method from Drupal core or a contrib base class, use
+`@phpstan-param` and `@phpstan-return` rather than plain `@param`/`@return`.
+This tells PHPStan the precise types without conflicting with the parent's
+docblock.
+
+This is critical for:
+- Plugin constructors extending `PluginBase`, `ProcessPluginBase`, etc.
+- `create()` factory methods from `ContainerFactoryPluginInterface`
+- `getDerivativeDefinitions()` from `DeriverInterface`
+- Any overridden method where you need tighter types than the parent declares
+
+```php
+/**
+ * {@inheritdoc}
+ *
+ * @phpstan-param array<string, mixed> $configuration
+ * @phpstan-param string $plugin_id
+ * @phpstan-param mixed $plugin_definition
+ */
+public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    private readonly Connection $database,
+) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+}
+```
+
+### Parameter Contravariance
+
+When PHPStan reports `method.childParameterType`, the child method has a more
+specific parameter type than the parent. Fix it with `@phpstan-param` using the
+parent's broader type:
+
+```php
+/**
+ * {@inheritdoc}
+ *
+ * @phpstan-param array<array-key, mixed> $base_plugin_definition
+ */
+public function getDerivativeDefinitions($base_plugin_definition): array {
+```
+
+### Return Type: `static` vs Concrete
+
+When a method returns `new ClassName()` but the parent's return type is `static`,
+PHPStan flags `return.type`. Fix by making the class `final` and using the
+concrete class name as the return type:
+
+```php
+final class MyPlugin extends ProcessPluginBase implements ContainerFactoryPluginInterface {
+    public static function create(
+        ContainerInterface $container,
+        array $configuration,
+        $plugin_id,
+        $plugin_definition,
+    ): MyPlugin {
+        return new MyPlugin(
+            $configuration,
+            $plugin_id,
+            $plugin_definition,
+            $container->get('database'),
+        );
+    }
+}
+```
+
+Use `final` on any class that isn't explicitly designed to be extended. This is
+the project convention for leaf services, hook classes, plugins, and handlers.
+
+### Type Narrowing with Assertions
+
+When working with Drupal's loosely-typed APIs, use `assert()` to narrow types
+rather than `@phpstan-ignore-next-line`:
+
+```php
+$storage = $this->entityTypeManager->getStorage('node');
+assert($storage instanceof NodeStorageInterface);
+$node = $storage->load($nid);
+```
+
+### Null Safety
+
+Always handle nullable returns explicitly:
+
+```php
+$statement = $query->execute();
+if ($statement === NULL) {
+    return [];
+}
+$results = $statement->fetchAll();
+```
+
+### Array Type Annotations
+
+PHPStan level 8 requires specific array types — plain `array` without type
+parameters triggers "no value type specified in iterable type array". Always
+specify what the array contains:
+
+```php
+/** @var array<string, mixed> */
+/** @var list<int> */
+/** @var array<int, array{id: int, name: string}> */
+```
+
+For simple one-dimensional arrays:
+
+```php
+/**
+ * @phpstan-param array<array-key, string> $items
+ */
+public function process(array $items): void {
+```
+
+For complex nested structures (like Drupal render arrays or form structures),
+you can describe the shape precisely:
+
+```php
+/**
+ * @phpstan-param array{data?: string|array{preview?: string|array{'#access'?: bool}}} $variables
+ */
+```
+
+Or use the escape hatch when the structure is too complex to describe:
+
+```php
+/**
+ * @phpstan-param array<array-key, mixed> $variables
+ */
+```
+
+When you find yourself writing deeply nested array shape annotations, consider
+whether a DTO class would be clearer. Classes give you actual type enforcement
+rather than just documentation.
+
+### Strict Comparisons and Boolean Conditions
+
+PHPStan strict rules ban several loose PHP patterns:
+
+**No `empty()`** — it's a loose comparison that conflates `null`, `false`, `0`,
+`''`, and `[]`. Use explicit checks instead:
+
+```php
+// Wrong
+if (empty($variable)) {
+
+// Right — check what you actually mean
+if ($variable === NULL || $variable === '') {
+```
+
+**Only booleans in `if` conditions** — a `mixed` or `string` in an `if` won't
+pass. Be explicit:
+
+```php
+// Wrong
+if ($variables['data']) {
+
+// Right
+if (isset($variables['data']) && $variables['data'] !== '') {
+```
+
+**`in_array()` requires strict mode** — always pass `true` as the third
+parameter. Same for `array_search()`, `array_keys()` with a search value,
+and `base64_decode()`:
+
+```php
+// Wrong
+\in_array($value, $allowed);
+
+// Right
+\in_array($value, $allowed, true);
+```
+
+**No short ternary (`?:`)** — it uses loose boolean evaluation. Use the null
+coalesce operator `??` or a full ternary with an explicit condition:
+
+```php
+// Wrong (loose boolean coercion)
+$name = $input ?: 'default';
+
+// Right (null coalesce — strict null check)
+$name = $input ?? 'default';
+
+// Right (explicit condition when you need non-null, non-empty)
+$name = ($input !== '' && $input !== NULL) ? $input : 'default';
+```
+
+### Contravariance and Covariance
+
+PHPStan enforces the Liskov Substitution Principle:
+
+- **Parameters are contravariant**: a child class method can accept a broader
+  type than the parent, but never a narrower one. If the parent takes `Animal`,
+  the child cannot restrict to `Mammal`.
+- **Return types are covariant**: a child class method can return a narrower
+  type than the parent, but never a broader one. If the parent returns `Book`,
+  the child cannot widen to `Product`.
+
+In practice this most often appears with Drupal plugin base classes where the
+parent uses `array` and you want `array<string, mixed>`. Fix it with
+`@phpstan-param` using the parent's broader type (see "Parameter Contravariance"
+above).
+
+### Parent Constructor Calls
+
+When extending a class, the child constructor must call `parent::__construct()`.
+A common trap with Drupal plugin attributes: if you declare a parameter as
+`public readonly` (constructor promotion) and also pass it to the parent, you
+get "Readonly property is already assigned." The fix is to drop the promotion
+on the parameter that's forwarded to the parent:
+
+```php
+// Wrong — $id is promoted AND passed to parent
+final class MyAttribute extends AttributeBase {
+    public function __construct(
+        public readonly string $id,  // promoted to property
+        public readonly ?TranslatableMarkup $label,
+    ) {
+        parent::__construct($id);  // Error: $id already assigned
+    }
+}
+
+// Right — $id is NOT promoted, just forwarded
+final class MyAttribute extends AttributeBase {
+    public function __construct(
+        string $id,  // plain parameter, not promoted
+        public readonly ?TranslatableMarkup $label,
+    ) {
+        parent::__construct($id);
+    }
+}
+```
+
+### @SuppressWarnings Syntax
+
+When you need `@SuppressWarnings(PHPMD.UnusedFormalParameter)` in a docblock,
+always use double quotes around the value. Without quotes, PHPStan parses the
+dot as unexpected syntax and reports `phpDoc.parseError`:
+
+```php
+// Wrong — causes PHPStan phpDoc.parseError
+/**
+ * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+ */
+
+// Right
+/**
+ * @SuppressWarnings("PHPMD.UnusedFormalParameter")
+ */
+```
+
+### Common PHPStan Errors Reference
+
+For a comprehensive catalog of PHPStan level 8 + strict rules errors with
+detailed examples and fixes, see `references/phpstan-common-errors.md`.
+Consult that reference when you encounter a specific PHPStan error you're
+unsure how to fix.
+
+---
+
+## PHPMD Rules
+
+PHPMD checks code complexity and design. The project uses all rulesets
+except `cleancode`, with some customized thresholds.
+
+### Complexity Limits
+
+| Metric                   | Limit         | What it means                      |
+|--------------------------|---------------|------------------------------------|
+| Cyclomatic complexity    | 10 (default)  | Max branches/conditions per method |
+| NPath complexity         | 200 (default) | Max execution paths per method     |
+| Too many fields          | 18            | Max properties per class           |
+| Too many public methods  | 12            | (ignoring get/set/is prefixes)     |
+| Coupling between objects | 20            | Max unique classes referenced      |
+| Number of children       | 25            | Max classes extending this one     |
+
+When a method's complexity exceeds the limit, **refactor** — don't suppress.
+Extract private helper methods, use early returns, apply guard clauses:
+
+```php
+// Instead of one method with CC=15:
+public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, string $destination_property): mixed {
+    $data = $this->extractData($row);
+
+    return $this->buildResult($data);
+}
+
+private function extractData(Row $row): array {
+    // focused extraction logic
+}
+
+private function buildResult(array $data): mixed {
+    // focused building logic
+}
+```
+
+### Naming Rules
+
+| Rule                     | Constraint                                                                        |
+|--------------------------|-----------------------------------------------------------------------------------|
+| Short method name        | Minimum 2 characters                                                              |
+| Long class name          | Maximum 60 characters (subtracting Controller/Service/Interface/Manager suffixes) |
+| Short/Long variable name | **Not enforced** (excluded)                                                       |
+| CamelCase parameters     | **Not enforced** (excluded — Drupal uses snake_case parameters)                   |
+| CamelCase variables      | **Not enforced** (excluded)                                                       |
+
+### Unused Code
+
+- Unused local variables are flagged, **except** in foreach loops
+- Unused private methods and properties are flagged
+- Unused formal parameters: use `@SuppressWarnings("PHPMD.UnusedFormalParameter")`
+  only when the parameter is required by a hook or interface signature you cannot
+  change. This is the one suppression that is routinely acceptable.
+
+---
+
+## CSpell
+
+CSpell checks spelling in identifiers, comments, and string literals.
+Minimum word length is 4 characters. Language is en-US with Italian dictionary.
+
+### Handling Unknown Words
+
+When you introduce a new technical term, acronym, or domain-specific word that
+CSpell would flag, add it to the project dictionary:
+
+**File:** `src/drupal/project-dictionary.txt`
+
+Add one word per line. Keep it alphabetically sorted.
+
+Common categories of words to add:
+- Drupal contrib module names (`metatag`, `pathauto`, `linkit`)
+- External service names and acronyms
+- Domain-specific Italian terms
+- API endpoint names and technical jargon
+
+The firestarter platform dictionary already includes: `behat`, `cex`, `cim`,
+`drush`, `firestarter`, `langcode`, `metatag`, `oembed`, `renderable`,
+`sparkfabrik`, `yamls`, and a few others.
+
+---
+
+## Project Code Patterns
+
+The project follows specific conventions for different class types. Matching
+these patterns ensures consistency and avoids QA issues.
+
+### Hook Classes (Drupal 11 style)
+
+Prefer OOP hooks with `#[Hook]` attributes over procedural `.module` functions.
+Hook classes live in `src/Hook/` and are registered as autowired services.
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\my_module\Hook;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Hook\Attribute\Hook;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+
+final readonly class NodeHooks {
+
+    use StringTranslationTrait;
+
+    public function __construct(
+        private MyServiceInterface $myService,
+    ) {}
+
+    #[Hook('entity_access')]
+    public function checkAccess(
+        EntityInterface $entity,
+        string $operation,
+        AccountInterface $account,
+    ): AccessResultInterface {
+        // implementation
+
+        return AccessResult::neutral();
+    }
+
+}
+```
+
+Key points:
+- `final readonly class` when no mutable state
+- Constructor promotion with `private readonly`
+- One blank line before `return`
+- Trailing commas everywhere
+
+### Services and Dependency Injection
+
+All `*.services.yml` files use autowiring:
+
+```yaml
+services:
+  _defaults:
+    autoconfigure: true
+    autowire: true
+
+  Drupal\my_module\Hook\NodeHooks: ~
+
+  Drupal\my_module\Infrastructure\Persistence\Repository\NodeRepository: ~
+  Drupal\my_module\Entity\NodeRepositoryInterface:
+    alias: Drupal\my_module\Infrastructure\Persistence\Repository\NodeRepository
+```
+
+For classes that need explicit service wiring (named services, logger channels):
+
+```php
+public function __construct(
+    #[Autowire(service: 'logger.channel.my_module')]
+    private readonly LoggerInterface $logger,
+) {}
+```
+
+### Migration Process Plugins
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\my_module\Plugin\migrate\process;
+
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\migrate\Attribute\MigrateProcess;
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\ProcessPluginBase;
+use Drupal\migrate\Row;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+#[MigrateProcess('my_process')]
+final class MyProcess extends ProcessPluginBase implements ContainerFactoryPluginInterface {
+
+    /**
+     * @phpstan-param array<string, mixed> $configuration
+     * @phpstan-param string $plugin_id
+     * @phpstan-param mixed $plugin_definition
+     */
+    public function __construct(
+        array $configuration,
+        $plugin_id,
+        $plugin_definition,
+        private readonly Connection $database,
+    ) {
+        parent::__construct($configuration, $plugin_id, $plugin_definition);
+    }
+
+    /**
+     * @phpstan-param array<string, mixed> $configuration
+     */
+    public static function create(
+        ContainerInterface $container,
+        array $configuration,
+        $plugin_id,
+        $plugin_definition,
+    ): MyProcess {
+        return new MyProcess(
+            $configuration,
+            $plugin_id,
+            $plugin_definition,
+            $container->get('database'),
+        );
+    }
+
+    /**
+     * @phpstan-return string|list<array{id: int, revision_id: int}>
+     */
+    public function transform(
+        mixed $value,
+        MigrateExecutableInterface $migrate_executable,
+        Row $row,
+        string $destination_property,
+    ): mixed {
+        // implementation
+
+        return $value;
+    }
+
+}
+```
+
+### Symfony Messenger Handlers
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\my_module\Messenger;
+
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler]
+final readonly class MyMessageHandler {
+
+    public function __construct(
+        #[Autowire(service: 'logger.channel.my_module')]
+        private LoggerInterface $logger,
+        private MyRepositoryInterface $repository,
+    ) {}
+
+    public function __invoke(MyMessage $message): void {
+        // implementation
+    }
+
+}
+```
+
+### Block Plugins
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\my_module\Plugin\Block;
+
+use Drupal\Core\Block\Attribute\Block;
+use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+#[Block(
+    id: 'my_block',
+    admin_label: new TranslatableMarkup('My Block'),
+)]
+final class MyBlock extends BlockBase implements ContainerFactoryPluginInterface {
+
+    /**
+     * @phpstan-param array<string, mixed> $configuration
+     * @phpstan-param string $plugin_id
+     * @phpstan-param mixed $plugin_definition
+     */
+    public function __construct(
+        array $configuration,
+        $plugin_id,
+        $plugin_definition,
+        private readonly EntityTypeManagerInterface $entityTypeManager,
+    ) {
+        parent::__construct($configuration, $plugin_id, $plugin_definition);
+    }
+
+    /**
+     * @phpstan-param array<string, mixed> $configuration
+     */
+    public static function create(
+        ContainerInterface $container,
+        array $configuration,
+        $plugin_id,
+        $plugin_definition,
+    ): MyBlock {
+        return new MyBlock(
+            $configuration,
+            $plugin_id,
+            $plugin_definition,
+            $container->get('entity_type.manager'),
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function build(): array {
+        return [
+            '#markup' => $this->t('Hello'),
+        ];
+    }
+
+}
+```
+
+### Repository Pattern
+
+The project uses an infrastructure layer with interface aliasing:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\my_module\Infrastructure\Persistence\Repository;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+
+final readonly class NodeRepository implements NodeRepositoryInterface {
+
+    public function __construct(
+        private EntityTypeManagerInterface $entityTypeManager,
+    ) {}
+
+    /**
+     * @return list<int>
+     */
+    public function findPublishedByBundle(string $bundle): array {
+        $storage = $this->entityTypeManager->getStorage('node');
+        $ids = $storage->getQuery()
+            ->accessCheck(FALSE)
+            ->condition('type', $bundle)
+            ->condition('status', 1)
+            ->execute();
+
+        return \array_values(\array_map('\intval', $ids));
+    }
+
+}
+```
+
+---
+
+## Quick Checklist
+
+Before writing any PHP, mentally run through this list:
+
+1. `declare(strict_types=1);` at the top
+2. `use` statements sorted alphabetically
+3. Global functions prefixed with `\` — `\count()`, `\array_map()`, etc.
+4. Trailing commas on multi-line calls, declarations, and arrays
+5. Blank line before `return` and `continue`
+6. Class members in correct order: traits, constants, properties, constructor, public methods, other methods, magic methods
+7. Return type hints on every method
+8. `@phpstan-param` / `@phpstan-return` for overridden methods
+9. `final` on classes not designed for extension
+10. `assert()` for type narrowing, not `@phpstan-ignore`
+11. Method complexity under 10 — extract helpers if needed
+12. No debug statements (`var_dump`, `die`, `error_log`, etc.)
+13. New technical terms added to `src/drupal/project-dictionary.txt`
+14. `static` keyword on closures that don't use `$this`
+15. Null-safe operator `?->` where applicable
+16. No `empty()` — use explicit comparisons (`=== null`, `=== ''`, `=== []`)
+17. Only booleans in `if` conditions — no bare `if ($variable)`
+18. `\in_array($v, $arr, true)` — always pass strict `true` as third param
+19. No short ternary `?:` — use `??` or full ternary with explicit condition
+20. Array params always typed — `array<array-key, mixed>` at minimum, not bare `array`
+21. `@SuppressWarnings("PHPMD.X")` with double quotes (not unquoted)
+22. Don't promote constructor params that are forwarded to `parent::__construct()`

--- a/skills/drupal/drupal-php-standards/references/phpstan-common-errors.md
+++ b/skills/drupal/drupal-php-standards/references/phpstan-common-errors.md
@@ -1,0 +1,457 @@
+# PHPStan Level 8 + Strict Rules: Common Errors Reference
+
+This reference catalogs the most frequent PHPStan errors encountered in this
+project, with concrete before/after examples. The SKILL.md covers the
+principles; this file has the full error messages and detailed fixes.
+
+## Table of Contents
+
+1. [No value type specified in iterable type array](#1-no-value-type-specified-in-iterable-type-array)
+2. [Construct empty() is not allowed](#2-construct-empty-is-not-allowed)
+3. [Only booleans are allowed in if condition](#3-only-booleans-are-allowed-in-if-condition)
+4. [in_array() requires parameter #3 to be set](#4-in_array-requires-parameter-3-to-be-set)
+5. [Short ternary operator is not allowed](#5-short-ternary-operator-is-not-allowed)
+6. [Parameter is not contravariant](#6-parameter-is-not-contravariant)
+7. [Return type is not covariant](#7-return-type-is-not-covariant)
+8. [Does not call parent constructor](#8-does-not-call-parent-constructor)
+9. [Readonly property already assigned](#9-readonly-property-already-assigned)
+10. [@SuppressWarnings has invalid value](#10-suppresswarnings-has-invalid-value)
+11. [Return type static vs concrete class](#11-return-type-static-vs-concrete-class)
+12. [@phpstan-param for inherited methods](#12-phpstan-param-for-inherited-methods)
+
+---
+
+## 1. No value type specified in iterable type array
+
+**Error:** `Function x() has parameter $y with no value type specified in iterable type array.`
+
+PHPStan level 8 requires all array parameters and return types to declare
+what they contain. A bare `array` type is not acceptable.
+
+### Simple arrays (one type of element)
+
+```php
+// Error
+function process(array $items): void {
+
+// Fix — specify key and value types
+/**
+ * @phpstan-param array<array-key, string> $items
+ */
+function process(array $items): void {
+```
+
+### Associative arrays with known keys
+
+```php
+// Fix — use array shape syntax for known structures
+/**
+ * @phpstan-param array{name: string, age: int, email?: string} $user
+ */
+function createUser(array $user): void {
+```
+
+### Nested arrays (Drupal render arrays, form structures)
+
+When the structure is known, describe it precisely:
+
+```php
+/**
+ * @phpstan-param array{data?: string|array{preview?: string|array{'#access'?: bool}}} $variables
+ */
+function preprocess(array $variables): void {
+    if (!isset($variables['data']) || !\is_array($variables['data'])) {
+        return;
+    }
+
+    $data = &$variables['data'];
+
+    if (!isset($data['preview']) || !\is_array($data['preview'])) {
+        return;
+    }
+
+    if (isset($data['preview']['#access']) && $data['preview']['#access'] === FALSE) {
+        unset($data['preview']);
+    }
+}
+```
+
+When the structure is too complex or truly dynamic, use the escape hatch:
+
+```php
+/**
+ * @phpstan-param array<array-key, mixed> $variables
+ */
+function preprocess(array $variables): void {
+```
+
+**Why not level 9?** Level 9+ requires strict handling of `mixed` — you can
+only pass `mixed` to another `mixed`. Using `array<array-key, mixed>` at
+level 8 gives you a workable escape hatch that level 9 would close.
+
+**Best practice:** If you find yourself writing deeply nested array shape
+annotations, consider whether a DTO class would be clearer. A class with typed
+properties gives you actual enforcement, not just documentation.
+
+---
+
+## 2. Construct empty() is not allowed
+
+**Error:** `Construct empty() is not allowed. Use more strict comparison.`
+
+`empty()` is a loose comparison that treats `null`, `false`, `0`, `''`, `'0'`,
+and `[]` all as "empty." The strict rules ban it because it hides bugs where
+`0` or `'0'` are valid values.
+
+```php
+// Error
+if (empty($variable)) {
+
+// Fix — be explicit about what "empty" means for your case
+// If checking for null or empty string:
+if ($variable === null || $variable === '') {
+
+// If checking for null only:
+if ($variable === null) {
+
+// If checking for empty array:
+if ($variable === []) {
+
+// If checking for falsy (and you've thought about it):
+if ($variable === null || $variable === false || $variable === '') {
+```
+
+---
+
+## 3. Only booleans are allowed in if condition
+
+**Error:** `Only booleans are allowed in an if condition, mixed given.`
+
+PHP's loose type coercion lets you write `if ($variable)` when `$variable`
+is a string or mixed. The strict rules require an explicit boolean expression.
+
+```php
+// Error
+if ($variables['data']) {
+
+// Fix — explicit comparison
+if ($variables['data'] === TRUE) {
+
+// Or for existence + non-empty:
+if (isset($variables['data']) && $variables['data'] !== '') {
+
+// For checking non-null:
+if ($variables['data'] !== NULL) {
+```
+
+This also applies to negation:
+
+```php
+// Error
+if (!$value) {
+
+// Fix
+if ($value === NULL) {
+// or
+if ($value === FALSE) {
+// or
+if ($value === '' || $value === NULL) {
+```
+
+---
+
+## 4. in_array() requires parameter #3 to be set
+
+**Error:** `Call to function in_array() requires parameter #3 to be set.`
+
+The `$strict` parameter defaults to `false`, meaning `in_array()` uses loose
+comparison (`==`). The strict rules require explicit `true`.
+
+```php
+// Error
+\in_array($value, $allowed);
+
+// Fix
+\in_array($value, $allowed, true);
+```
+
+Same requirement applies to:
+- `\array_search($needle, $haystack, true)`
+- `\array_keys($array, $search_value, true)` (when using the search parameter)
+- `\base64_decode($string, true)`
+
+---
+
+## 5. Short ternary operator is not allowed
+
+**Error:** `Short ternary operator is not allowed. Use null coalesce operator if applicable or consider using long ternary.`
+
+The short ternary `$a ?: $b` uses PHP's loose boolean evaluation. A value
+of `0`, `'0'`, or `''` would bypass to the fallback, which is often a bug.
+
+```php
+// Error
+$name = $input ?: 'default';
+
+// Fix — use null coalesce (strict null check)
+$name = $input ?? 'default';
+
+// Fix — use full ternary with explicit condition
+$name = ($input !== '' && $input !== null) ? $input : 'default';
+```
+
+Use `??` when you only want to replace `null`. Use a full ternary when you
+need to exclude other specific values.
+
+---
+
+## 6. Parameter is not contravariant
+
+**Error:** `Parameter #1 $x (SpecificType) of method Child::method() should be contravariant with parameter $x (BroaderType) of method Parent::method().`
+
+A child class method's parameters must accept the same type or broader than
+the parent's. Narrowing the type breaks the Liskov Substitution Principle:
+any code that calls the parent's method with a valid argument must also work
+when given the child class.
+
+```php
+// Error — child narrows Animal to Mammal
+class AnimalFeeder {
+    public function feed(Animal $animal): void {}
+}
+
+class MammalFeeder extends AnimalFeeder {
+    public function feed(Mammal $animal): void {}  // Violation!
+}
+```
+
+In Drupal, this most commonly appears when a parent declares `array` and
+the child uses `array<string, mixed>`:
+
+```php
+// Error — child's @param is more specific than parent
+/**
+ * @param array<string, mixed> $base_plugin_definition
+ */
+public function getDerivativeDefinitions($base_plugin_definition): array {
+
+// Fix — use @phpstan-param with the parent's broader type
+/**
+ * {@inheritdoc}
+ *
+ * @phpstan-param array<array-key, mixed> $base_plugin_definition
+ */
+public function getDerivativeDefinitions($base_plugin_definition): array {
+```
+
+---
+
+## 7. Return type is not covariant
+
+**Error:** `Return type (BroaderType) of method Child::method() is not covariant with return type (SpecificType) of method Parent::method().`
+
+A child class method's return type must be the same or narrower than the
+parent's. Widening it breaks LSP: callers expecting the parent's specific
+return type would get something less specific.
+
+```php
+// Error — child widens Book to Product
+class BookFactory {
+    public function create(): Book { return new Book(); }
+}
+
+class GenericFactory extends BookFactory {
+    public function create(): Product { return new Product(); }  // Violation!
+}
+```
+
+Fix by returning the same type or a subtype of the parent's return type.
+
+---
+
+## 8. Does not call parent constructor
+
+**Error:** `ChildClass::__construct() does not call parent constructor from ParentClass.`
+
+When extending a class that has a constructor, the child must call
+`parent::__construct()`. This is especially common with Drupal plugin
+attributes extending `AttributeBase`.
+
+```php
+// Error — no parent::__construct() call
+final class MyAttribute extends AttributeBase {
+    public function __construct(
+        public readonly string $id,
+        public readonly ?TranslatableMarkup $label,
+    ) {}
+}
+
+// Fix — call parent constructor
+final class MyAttribute extends AttributeBase {
+    public function __construct(
+        string $id,  // NOT promoted — see next section
+        public readonly ?TranslatableMarkup $label,
+    ) {
+        parent::__construct($id);
+    }
+}
+```
+
+---
+
+## 9. Readonly property already assigned
+
+**Error:** `Readonly property ClassName::$id is already assigned.`
+
+This happens when you use constructor promotion (`public readonly`) for a
+parameter that you also pass to `parent::__construct()`. The parent
+assigns the property, and then the promotion tries to assign it again.
+
+```php
+// Error — $id is promoted AND forwarded to parent
+final class MyAttribute extends AttributeBase {
+    public function __construct(
+        public readonly string $id,  // Promoted → assigns $this->id
+        public readonly ?TranslatableMarkup $label,
+    ) {
+        parent::__construct($id);  // Parent also assigns $this->id → Error!
+    }
+}
+
+// Fix — don't promote the parameter that the parent needs
+final class MyAttribute extends AttributeBase {
+    public function __construct(
+        string $id,  // Plain parameter, not promoted
+        public readonly ?TranslatableMarkup $label,
+    ) {
+        parent::__construct($id);  // Parent handles the assignment
+    }
+}
+```
+
+The rule: if a parent constructor accepts and stores a value, don't use
+constructor promotion for that parameter in the child. Only promote
+parameters that are unique to the child class.
+
+---
+
+## 10. @SuppressWarnings has invalid value
+
+**Error:** `PHPDoc tag @SuppressWarnings has invalid value ((PHPMD.UnusedFormalParameter)): Unexpected token ".UnusedFormalParameter)", expected ')' at offset 156`
+
+PHPStan parses docblocks and trips on the unquoted `PHPMD.UnusedFormalParameter`
+because the dot is unexpected syntax. Wrap it in double quotes:
+
+```php
+// Error
+/**
+ * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+ */
+
+// Fix
+/**
+ * @SuppressWarnings("PHPMD.UnusedFormalParameter")
+ */
+```
+
+This applies to all PHPMD suppression annotations:
+- `@SuppressWarnings("PHPMD.CyclomaticComplexity")`
+- `@SuppressWarnings("PHPMD.NPathComplexity")`
+- `@SuppressWarnings("PHPMD.ExcessiveMethodLength")`
+- etc.
+
+---
+
+## 11. Return type static vs concrete class
+
+**Error:** `Method ClassName::create() should return static(ClassName) but returns ClassName.`
+
+When a parent method declares `static` as its return type and you return
+`new ClassName()`, PHPStan flags the mismatch. Fix by making the class
+`final` and using the concrete class name as the return type:
+
+```php
+// Error
+class MyPlugin extends ProcessPluginBase {
+    public static function create(...): static {
+        return new MyPlugin(...);  // Returns ClassName, not static
+    }
+}
+
+// Fix — final class + concrete return type
+final class MyPlugin extends ProcessPluginBase {
+    public static function create(...): MyPlugin {
+        return new MyPlugin(...);
+    }
+}
+```
+
+If the class cannot be `final` (it's designed to be extended), use
+`new static()` instead:
+
+```php
+class MyBasePlugin extends ProcessPluginBase {
+    public static function create(...): static {
+        return new static(...);  // Returns the actual class at runtime
+    }
+}
+```
+
+---
+
+## 12. @phpstan-param for inherited methods
+
+When overriding methods from Drupal core or contrib, use `@phpstan-param`
+instead of `@param` for type annotations. This tells PHPStan the precise
+types without creating a conflict with the parent's existing docblock.
+
+Common cases:
+
+```php
+// Plugin constructor
+/**
+ * @phpstan-param array<string, mixed> $configuration
+ * @phpstan-param string $plugin_id
+ * @phpstan-param mixed $plugin_definition
+ */
+public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    private readonly Connection $database,
+) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+}
+
+// Factory method
+/**
+ * @phpstan-param array<string, mixed> $configuration
+ */
+public static function create(
+    ContainerInterface $container,
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+): MyPlugin {
+
+// Deriver
+/**
+ * @phpstan-param array<array-key, mixed> $base_plugin_definition
+ * @phpstan-return array<string, array<string, mixed>>
+ */
+public function getDerivativeDefinitions($base_plugin_definition): array {
+
+// Process plugin transform
+/**
+ * @phpstan-return string|list<array{id: int, revision_id: int}>
+ */
+public function transform(
+    mixed $value,
+    MigrateExecutableInterface $migrate_executable,
+    Row $row,
+    string $destination_property,
+): mixed {
+```
+
+Use `@phpstan-param` whenever the method comes from a parent class in Drupal
+core or contrib. For methods you define yourself, regular `@param` is fine.

--- a/skills/drupal/drupal-qa/SKILL.md
+++ b/skills/drupal/drupal-qa/SKILL.md
@@ -1,0 +1,543 @@
+---
+name: drupal-qa
+description: Fix Drupal code quality issues (PHPCS, PHPMD, PHPStan, CSpell) following SparkFabrik standards without
+   using suppressions or ignores unless absolutely necessary.
+---
+
+# SparkFabrik Drupal QA Skill
+
+## Purpose
+Fix Drupal code quality issues (PHPCS, PHPMD, PHPStan, CSpell) following SparkFabrik standards without using suppressions or ignores unless absolutely necessary.
+
+## When to Use
+Use this skill when:
+- Pre-commit hooks fail with QA errors
+- You need to fix code quality issues in Drupal modules
+- `make drupal-qa` reports errors
+- User explicitly requests QA fixes
+
+## Core Principles
+
+### 1. Fix, Don't Suppress
+**ALWAYS prefer fixing the actual issue over suppressing warnings.**
+
+❌ **BAD**: Add `@SuppressWarnings(PHPMD.CyclomaticComplexity)`
+✅ **GOOD**: Refactor method to reduce complexity
+
+❌ **BAD**: Add `// @phpstan-ignore-next-line`
+✅ **GOOD**: Add proper type assertions or fix the actual type issue
+
+❌ **BAD**: Add global ignoreErrors in phpstan.neon
+✅ **GOOD**: Fix each issue individually with proper types
+
+### 2. PHPStan Annotations for Inherited Methods
+When inheriting from Drupal core classes or interfaces (like `ContainerFactoryPluginInterface`, `PluginBase`, `ProcessPluginBase`, `DeriverInterface`), use `@phpstan-param` and `@phpstan-return` instead of regular `@param` and `@return` to avoid conflicting with parent documentation:
+
+❌ **BAD**:
+```php
+/**
+ * Constructs a MyPlugin plugin.
+ *
+ * @param array<string, mixed> $configuration
+ *   The plugin configuration.
+ * @param string $plugin_id
+ *   The plugin ID.
+ */
+public function __construct(array $configuration, $plugin_id, $plugin_definition) {
+  parent::__construct($configuration, $plugin_id, $plugin_definition);
+}
+```
+
+✅ **GOOD**:
+```php
+/**
+ * {@inheritdoc}
+ *
+ * @phpstan-param array<string, mixed> $configuration
+ *   The plugin configuration.
+ * @phpstan-param string $plugin_id
+ *   The plugin ID.
+ * @phpstan-param mixed $plugin_definition
+ *   The plugin definition.
+ */
+public function __construct(array $configuration, $plugin_id, $plugin_definition) {
+  parent::__construct($configuration, $plugin_id, $plugin_definition);
+}
+```
+
+**When to use `@phpstan-*`:**
+- In `__construct()` for plugins extending base classes like `PluginBase`
+- In `create()` for plugins implementing `**ContainerFactoryPluginInterface**`
+- In `getDerivativeDefinitions()` for classes implementing `DeriverInterface`
+- Any method from custom module sources that overrides a parent method from Drupal core or contrib modules
+
+### 3. Fix `static` Return Type Errors with Concrete Class Names
+When PHPStan reports a `return.type` error like:
+
+```
+Method Drupal\luiss_migrate\Plugin\migrate\Deriver\LuissPageRichAccordionParagraphDeriver::create() should return
+         static(Drupal\luiss_migrate\Plugin\migrate\Deriver\LuissPageRichAccordionParagraphDeriver) but returns
+         Drupal\luiss_migrate\Plugin\migrate\Deriver\LuissPageRichAccordionParagraphDeriver.
+         🪪  return.type
+```
+
+This happens when a method returns `new ClassName()` instead of `new static()`, or when using `new static()` in a non-final class. The fix is to:
+1. **Change the return type from `static` to the concrete class name**
+2. **Make the class `final`**
+
+❌ **BAD**: Suppress the error
+```php
+// @phpstan-ignore-next-line return.type
+public static function create(...): static {
+  return new MyClass(...);
+}
+```
+
+❌ **BAD**: Keep using `static` return type
+```php
+class MyDeriver extends DeriverBase {
+  public static function create(ContainerInterface $container, $base_plugin_id): static {
+    return new MyDeriver();
+  }
+}
+```
+
+✅ **GOOD**: Use concrete class name and make class final
+```php
+final class MyDeriver extends DeriverBase implements ContainerDeriverInterface {
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, $base_plugin_id): MyDeriver {
+    return new MyDeriver();
+  }
+}
+```
+
+```php
+final class MyPlugin extends ProcessPluginBase implements ContainerFactoryPluginInterface {
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(
+    ContainerInterface $container,
+    array $configuration,
+    $plugin_id,
+    $plugin_definition
+  ): MyPlugin {
+    return new MyPlugin(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('database'),
+    );
+  }
+}
+```
+
+**Key points:**
+- Replace `static` with the concrete class name in the return type
+- Add `final` to the class definition to prevent inheritance issues
+- This applies to factory methods like `create()`, `createInstance()`, etc.
+
+**When NOT to use `final`:**
+- If the class is explicitly designed to be extended (base classes, abstract classes)
+- If other classes in the codebase already extend it
+
+In those rare cases where `final` is not possible, keep `static` as return type and ensure you use `new static()` instead of `new ClassName()`.
+
+### 4. Fix Parameter Contravariance Errors
+When PHPStan reports a `method.childParameterType` error like:
+
+> Parameter #1 $base_plugin_definition (array<string, mixed>) of method MyClass::getDerivativeDefinitions() should be contravariant with parameter $base_plugin_definition (array) of method ParentClass::getDerivativeDefinitions()
+
+This means the child method's parameter type is **more specific** than the parent's, violating the [Liskov Substitution Principle](https://en.wikipedia.org/wiki/Liskov_substitution_principle). In PHP, method parameters must be contravariant (same or broader type than parent).
+
+**The fix**: Add a `@phpstan-param` annotation with the broader type matching the parent's signature. This tells PHPStan to use the broader type for analysis without changing the actual PHP type hint.
+
+❌ **BAD**: Suppress or ignore
+```php
+// @phpstan-ignore-next-line method.childParameterType
+public function getDerivativeDefinitions($base_plugin_definition): array {
+```
+
+❌ **BAD**: Change the `@param` type to be more specific than the parent
+```php
+/**
+ * @param array<string, mixed> $base_plugin_definition
+ */
+public function getDerivativeDefinitions($base_plugin_definition): array {
+```
+
+✅ **GOOD**: Use `@phpstan-param` with the parent's broader type
+```php
+/**
+ * {@inheritdoc}
+ *
+ * @phpstan-param array<array-key, mixed> $base_plugin_definition
+ */
+public function getDerivativeDefinitions($base_plugin_definition): array {
+```
+
+**Common cases where this applies:**
+- `getDerivativeDefinitions($base_plugin_definition)` - parent uses `array`, child uses `array<string, mixed>`
+- `transform($value, ...)` - parent uses `mixed`, child uses a more specific type
+- `__construct(array $configuration, ...)` - parent uses `array`, child uses `array<string, mixed>`
+- Any overridden method where you've added generic type annotations that are stricter than the parent
+
+**How to determine the correct `@phpstan-param` type:**
+1. Look at the parent class/interface parameter type
+2. Use that same type (or broader) in the `@phpstan-param` annotation
+3. Common broader types: `array` becomes `array<array-key, mixed>`, specific types become `mixed`
+
+### 5. Type Assertions Over Ignores
+When PHPStan complains about type narrowing, use assertions:
+
+❌ **BAD**:
+```php
+// @phpstan-ignore-next-line method.notFound
+$paragraph->getRevisionId();
+```
+
+✅ **GOOD**:
+```php
+assert($paragraph instanceof RevisionableInterface);
+$revision_id = $paragraph->getRevisionId();
+```
+
+### 6. Refactor Complex Code
+When PHPMD reports high cyclomatic complexity:
+
+❌ **BAD**: Add `@SuppressWarnings(PHPMD.CyclomaticComplexity)`
+
+✅ **GOOD**: Extract methods to reduce complexity:
+```php
+// Before: 20 lines, CC=15
+public function transform($value, $exec, $row, $dest) {
+  // ... complex logic ...
+}
+
+// After: Multiple focused methods
+public function transform($value, $exec, $row, $dest) {
+  $data = $this->extractData($row);
+  return $this->processData($data);
+}
+
+private function extractData($row) { /* ... */ }
+private function processData($data) { /* ... */ }
+```
+
+### 7. When Suppressions Are Acceptable
+
+Only use suppressions in these specific cases:
+
+1. **Third-party code issues** - Code you cannot modify
+2. **Drupal core API limitations** - Framework constraints
+3. **False positives** - After confirming with user that it's truly a false positive
+
+**ALWAYS ask the user first** before adding any suppression.
+
+## Workflow
+
+### Step 1: Analyze QA Report
+Run `make drupal-qa` and categorize errors:
+
+```bash
+make drupal-qa
+```
+
+Categorize by type:
+- **PHPCS**: Code style (usually auto-fixable)
+- **CSpell**: Unknown words (add to dictionary)
+- **PHPMD**: Code complexity, unused code
+- **PHPStan**: Type safety issues
+
+You can run individual tools to speed up the process:
+
+```bash
+# Run PHPCS only
+make drupal-qa phpcs
+
+# Run CSpell only
+make drupal-qa cspell
+
+# Run PHPMD only
+make drupal-qa phpmd
+
+# Run PHPStan only
+make drupal-qa phpstan
+```
+
+**NEVER** run individual tools from bin directory! **ALWAYS** use the `make drupal-qa <tool>` command to ensure proper environment variables and configuration are applied.
+
+### Step 2: Fix PHPCS Issues
+- Long lines: Wrap them properly
+- Complex expressions: Simplify or break into multiple lines
+
+### Step 3: Fix CSpell Issues
+Add legitimate technical terms to dictionary:
+
+```bash
+# Edit src/drupal/project-dictionary.txt
+# Add one word per line, alphabetically sorted
+```
+
+### Step 4: Fix PHPMD Issues
+
+#### Cyclomatic Complexity
+**Target**: Keep CC < 10
+
+**Strategies**:
+1. **Extract methods**: Break down complex logic
+2. **Early returns**: Reduce nesting
+3. **Strategy pattern**: For multiple conditions
+4. **Guard clauses**: Check preconditions first
+
+Example refactoring:
+```php
+// Before: CC = 15
+private function processItem($item, $config) {
+  if ($config['type'] === 'image') {
+    if (isset($item['url'])) {
+      // ... 10 more lines
+    }
+  } elseif ($config['type'] === 'video') {
+    // ... more complex logic
+  }
+  // ... etc
+}
+
+// After: CC = 3
+private function processItem($item, $config) {
+  if ($config['type'] === 'image') {
+    return $this->processImage($item);
+  }
+  if ($config['type'] === 'video') {
+    return $this->processVideo($item);
+  }
+  return $this->processDefault($item);
+}
+
+private function processImage($item) { /* ... */ }
+private function processVideo($item) { /* ... */ }
+private function processDefault($item) { /* ... */ }
+```
+
+#### Unused Parameters
+If truly unused, remove them. If needed for interface compliance, document why:
+
+```php
+// Interface requires $langcode but we don't use it yet
+public function process($value, $langcode) {
+  // Document: $langcode reserved for future i18n support
+  return $this->doProcess($value);
+}
+```
+
+### Step 5: Fix PHPStan Issues
+
+#### Type Narrowing with Assertions
+```php
+// PHPStan error: Call to method on EntityInterface that doesn't exist
+
+// Add assertion to narrow type
+assert($entity instanceof ContentEntityInterface);
+$entity->hasField('field_name');
+```
+
+#### Missing Iterable Types
+Specify generic types:
+
+```php
+// Before: array
+/** @param array $items */
+
+// After: array with generic types
+/** @param array<int, string> $items */
+```
+
+#### Null Safety
+```php
+// Before: Possible null pointer
+$statement->fetchAll();
+
+// After: Null check
+$statement = $query->execute();
+if ($statement === NULL) {
+  return [];
+}
+$results = $statement->fetchAll();
+```
+
+#### Return Type Mismatches
+Fix the return type:
+
+```php
+// Before: Returns bool|int|string but expects int|string
+return is_scalar($value) ? $value : NULL;
+
+// After: Proper type filtering
+if (is_int($value) || is_string($value)) {
+  return $value;
+}
+return NULL;
+```
+
+### Step 6: Verify Fixes
+```bash
+make drupal-qa
+```
+
+All checks must pass before committing.
+
+## Common Drupal Patterns
+
+### Entity Type Assertions
+```php
+/** @var \Drupal\Core\Entity\ContentEntityStorageInterface $storage */
+$storage = $this->entityTypeManager->getStorage('media');
+
+// For specific storage types
+assert($storage instanceof MediaStorage);
+```
+
+### Dependency Injection
+Avoid `\Drupal::` static calls in classes:
+
+```php
+// Before
+$database = \Drupal::database();
+
+// After: Inject via constructor
+public function __construct(Connection $database) {
+  $this->database = $database;
+}
+
+public static function create(ContainerInterface $container, ...) {
+  return new static(
+    $container->get('database')
+  );
+}
+```
+
+### Plugin Configuration Arrays
+Specify types for plugin configuration using `@phpstan-param` when inheriting from Drupal core:
+
+```php
+// For __construct() overriding parent from ProcessPluginBase/PluginBase
+/**
+ * Constructs a MyPlugin plugin.
+ *
+ * @phpstan-param array<string, mixed> $configuration
+ *   The plugin configuration.
+ * @param string $plugin_id
+ *   The plugin ID.
+ * @param mixed $plugin_definition
+ *   The plugin definition.
+ * @param \Drupal\Core\Database\Connection $database
+ *   The database connection.
+ */
+public function __construct(
+  array $configuration,
+  $plugin_id,
+  $plugin_definition,
+  Connection $database,
+) {
+  parent::__construct($configuration, $plugin_id, $plugin_definition);
+}
+
+// For create() factory method
+/**
+ * {@inheritdoc}
+ *
+ * @phpstan-param array<string, mixed> $configuration
+ */
+public static function create(
+  ContainerInterface $container,
+  array $configuration,
+  $plugin_id,
+  $plugin_definition
+): static {
+  return new static(
+    $configuration,
+    $plugin_id,
+    $plugin_definition,
+    $container->get('database'),
+  );
+}
+```
+
+### Deriver getDerivativeDefinitions
+For DeriverInterface implementations, use `@phpstan-*` annotations:
+
+```php
+/**
+ * {@inheritdoc}
+ *
+ * @phpstan-param array<string, mixed> $base_plugin_definition
+ * @phpstan-return array<string, array<string, mixed>>
+ */
+public function getDerivativeDefinitions($base_plugin_definition): array {
+  // Implementation
+}
+```
+
+## Questions to Ask User
+
+When encountering these situations, **ALWAYS ask the user**:
+`****`
+1. **High complexity that's hard to refactor**
+   - "This method has CC=15. I can see it's handling complex migration logic. Would you like me to refactor it into smaller methods, or is there a reason to keep it as-is?"
+
+2. **Unused parameters from interface**
+   - "The parameter `$langcode` is required by the interface but not used. Should I: (a) implement i18n support, (b) document why it's unused, or (c) remove it if the interface allows?"
+
+3. **Drupal core API limitations**
+   - "PHPStan complains about `new static()` which is a standard Drupal plugin pattern. This appears to be a framework constraint. Should we add a baseline exception for this specific pattern?"
+
+4. **Unclear business logic**
+   - "I see complex conditional logic here but I'm not sure how to simplify it without changing behavior. Can you explain what this code does so I can refactor it properly?"
+
+5. **Potential false positives**
+   - "PHPStan reports this as an error, but it looks like the types are actually correct. Can you confirm this is a false positive before I investigate further?"
+
+## Anti-Patterns to Avoid
+
+### ❌ Don't: Add Global Ignores
+```php
+// phpstan.neon
+ignoreErrors:
+  - '#.*#'  // NEVER do this
+```
+
+### ❌ Don't: Suppress Without Understanding
+```php
+// @phpstan-ignore-next-line
+$result = $entity->getField();  // Why ignore? Fix the type issue!
+```
+
+### ❌ Don't: Use Empty Catch Blocks
+```php
+try {
+  $result = $query->execute();
+} catch (\Exception) {
+  // Silently failing - BAD!
+}
+```
+
+### ❌ Don't: Comment Out Code
+```php
+// Commented code to avoid PHPMD error - BAD!
+// $unused_variable = $this->calculateValue();
+```
+
+## Success Criteria
+
+QA is complete when:
+
+1. ✅ `make drupal-qa` passes with 0 errors
+2. ✅ No suppressions added (or user explicitly approved them)
+3. ✅ Code is more maintainable than before
+4. ✅ All legitimate technical terms in dictionary
+5. ✅ Type safety improved with assertions
+6. ✅ Complex methods refactored into smaller pieces


### PR DESCRIPTION
Added skills:

* drupal-ddd: Apply Domain-Driven Design patterns in Drupal 11 custom modules
* drupal-module-development: How to develop custom Drupal 11 modules on SparkFabrik's Firestarter platform
* drupal-php-standards: Write PHP code that passes all QA checks (PHPCS, PHPStan level 8, PHPMD, CSpell) on the first try
* drupal-qa: Fix Drupal code quality issues (PHPCS, PHPMD, PHPStan, CSpell) following SparkFabrik standards without
   using suppressions or ignores unless absolutely necessary