### PR TITLE
chore(skills): compress glab, playwright-cli, sf-create-agentsmd descriptions

### DIFF
--- a/config/upstream-skills.json
+++ b/config/upstream-skills.json
@@ -7,7 +7,7 @@
       "ref": "main",
       "path": "skills/playwright-cli",
       "frontmatter_overrides": {
-        "description": "Browser automation with the playwright-cli CLI tool. Use when the user needs to automate browser interactions, navigate websites, test web applications, take screenshots, fill forms, extract data from web pages, or interact with headless browsers. Also use when the user mentions \"playwright-cli\", \"playwright\", \"browser automation\", \"headless browser\", \"web scraping\", \"screenshot\", \"snapshot\", \"browser testing\", or wants to open, click, fill, or type in a web page."
+        "description": "Browser automation with the playwright-cli tool. Use when the user needs to automate browser interactions, test web apps, take screenshots, fill forms, or extract data from pages. Trigger on: \"playwright-cli\", \"playwright\", \"browser automation\", \"headless browser\", \"web scraping\", \"screenshot\", \"browser testing\", \"e2e test\"."
       }
     },
     {

--- a/skills/system/glab/SKILL.md
+++ b/skills/system/glab/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: glab
-description: 'Use the glab CLI for all GitLab tasks: issues, merge requests, CI/CD pipelines, releases, and repo files. Trigger when the user mentions "glab", "MR", "merge request", provides a GitLab URL, or the git remote points to GitLab. For GitLab file URLs use glab api instead of WebFetch. GitLab equivalent of the gh skill.'
+description: 'Invoke whenever the user is working with GitLab. Trigger on any of these signals: a URL containing "gitlab" (gitlab.com or any self-hosted instance like gitlab.sparkfabrik.com), a git remote pointing to GitLab (git@gitlab.com:... or https://gitlab...), the !N merge-request notation (!15, !42), or words like "merge request", "MR", "glab", or "gitlab". Handles issues, merge requests, CI/CD pipelines, releases, and reading files from GitLab repos. Always use glab—not WebFetch or curl—for any GitLab URL because GitLab requires authentication. Do not invoke for GitHub tasks (use the gh skill instead).'
 ---
 
 # glab CLI Skill

--- a/skills/system/glab/SKILL.md
+++ b/skills/system/glab/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: glab
-description: How to use the glab CLI to work with GitLab issues, merge requests, CI/CD pipelines, repository files, and releases. Use this skill whenever the user provides a URL containing "gitlab" in the hostname (e.g., gitlab.com, gitlab.example.com), mentions merge requests, GitLab issues, GitLab CI pipelines, or wants to interact with a GitLab remote. Also use this skill when the user mentions "glab", "MR", "merge request", or when you detect the git remote points to a GitLab instance (look for "gitlab" in the remote URL). This includes GitLab file URLs (raw files, blobs, tree views) -- use glab api to fetch file contents instead of WebFetch or curl. This skill is the GitLab equivalent of using `gh` for GitHub -- if the project is on GitLab, use this skill instead.
+description: 'Use the glab CLI for all GitLab tasks: issues, merge requests, CI/CD pipelines, releases, and repo files. Trigger when the user mentions "glab", "MR", "merge request", provides a GitLab URL, or the git remote points to GitLab. For GitLab file URLs use glab api instead of WebFetch. GitLab equivalent of the gh skill.'
 ---
 
 # glab CLI Skill

--- a/skills/system/sf-create-agentsmd/SKILL.md
+++ b/skills/system/sf-create-agentsmd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sf-create-agentsmd
-description: 'Generate or review AGENTS.md files for projects following team conventions. Use when bootstrapping a new project, creating AGENTS.md, reviewing an existing AGENTS.md for completeness, or auditing agent instructions. Also trigger on "create agents.md", "review agents.md", "bootstrap agents", "audit agents.md", "sf-create-agentsmd".'
+description: 'Generate or review AGENTS.md files following team conventions. Use when bootstrapping a project, creating or reviewing AGENTS.md, or auditing agent instructions. Trigger on: "create agents.md", "review agents.md", "bootstrap agents", "audit agents.md", "sf-create-agentsmd".'
 ---
 
 # SF Create AGENTS.md


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## Summary

- Compress `glab` description from 767 → 320 chars (main offender)
- Compress `playwright-cli` description from 353 → 272 chars (via `upstream-skills.json` override)
- Compress `sf-create-agentsmd` description from 333 → 258 chars
- All trigger keywords preserved; no skill body content changed
- Validated with `quick_validate.py` (structural) and `skill-creator` description quality review

## Why

`/doctor` in Claude Code reports these 3 skill descriptions are dropped at the default 1% context budget. The `glab` description was 2× longer than needed, pushing all three over the limit.

Closes #68