### PR TITLE
fix(gh): stop generating issue titles in commit format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Changes are grouped by date.
 ### Fixed
 
 - `glab` skill: stop generating GitLab issue titles in Conventional Commits format -- add an explicit "Issue title format" subsection requiring human-readable noun phrases (sentence case, under ~60 chars, no `feat:`/`fix:`/`chore:` prefixes, no `Bug:`/`Feature:` pseudo-prefixes), with categorization deferred to labels. Includes bad/good examples table. Four new eval cases (#27-#30) cover bug/feature/chore/docs prompts; eval #1 augmented with title-format assertions. Eval run: 25/25 (100%) on the patched skill vs 19/25 (76%) on the pre-fix snapshot
+- `gh` skill: stop generating GitHub issue titles in Conventional Commits format -- mirror the glab fix with an "Issue title format" subsection (human-readable noun phrases, sentence case, under ~60 chars, no `feat:`/`fix:`/`chore:` prefixes, no `Bug:`/`Feature:` pseudo-prefixes; categorization on labels). Includes bad/good examples table. Adds `## Issues` H2 heading that previously was missing. Four new eval cases (#14-#17) cover bug/feature/chore/docs prompts; eval #1 augmented with title-format assertions. Eval run: 25/25 (100%) on the patched skill vs 21/25 (84%) on the pre-fix snapshot
 - `glab` skill: document `-f` vs `-F` flag difference for `glab api` — `-f key=@file` sends the literal string while `-F key=@file` reads the file content; using the wrong flag silently corrupts note/description updates
 
 ## [2026-04-13]

--- a/skills/system/gh/SKILL.md
+++ b/skills/system/gh/SKILL.md
@@ -126,8 +126,36 @@ This applies to **every** piece of content the agent creates, regardless of leng
 
 ---
 
+## Issues
+
+### Issue title format
+
+Issue titles must be **human-readable, short, and concise** — a few words that express the goal or scope of the work. Issue titles are NOT commit messages and must NOT use the Conventional Commits format (no `feat:`, `fix(scope):`, `chore:` prefixes, no imperative commit-style phrasing).
+
+The title is read by humans scanning boards, backlogs, and notifications — it should describe **what the issue is about**, not how the eventual fix will be committed. Conventional Commits belongs on PR titles and commit messages, where it drives changelogs and tooling. Issues sit upstream of that, often before the solution is even known, so a commit-shaped title is both premature and harder to scan.
+
+Style guidelines:
+
+- Sentence case, no trailing period.
+- Aim for under ~60 characters.
+- Prefer noun phrases ("Slow dashboard load on Safari") or short problem statements ("Users locked out after password reset") over imperative verbs.
+- Do not prefix with `Bug:`, `Feature:`, `Task:`, etc. — use **labels** for categorization instead.
+
+**Examples:**
+
+| Bad (commit-shaped)                              | Good (human-readable)                |
+| ------------------------------------------------ | ------------------------------------ |
+| `feat(auth): add JWT token refresh`              | `JWT token refresh`                  |
+| `fix: prevent crash on empty password`           | `Login crash with empty password`    |
+| `docs(api): update rate limiting section`        | `Rate limiting docs out of date`     |
+| `refactor(parser): simplify config validation`   | `Simplify config parser`             |
+| `chore: bump dependencies`                       | `Update dependencies`                |
+| `Bug: login broken on Safari`                    | `Login broken on Safari`             |
+
+### Issue commands
+
 ```bash
-gh issue create --title "Bug: ..." --body "..." --label bug --label "high-priority" --assignee "@me"
+gh issue create --title "Login broken on Safari" --body "..." --label bug --label "high-priority" --assignee "@me"
 gh issue list --assignee @me                      # list my issues
 gh issue list --label "bug" --search "login"      # filter and search
 gh issue view 42 --comments                       # view with comments

--- a/skills/system/gh/evals/evals.json
+++ b/skills/system/gh/evals/evals.json
@@ -9,6 +9,9 @@
       "assertions": [
         "Uses `gh issue create` (not `glab issue create` or curl to the API)",
         "Includes a descriptive --title flag with relevant bug description",
+        "Title does NOT start with a Conventional Commits type prefix (no `feat:`, `fix:`, `fix(login):`, etc.)",
+        "Title does NOT start with a pseudo-category prefix like `Bug:` or `Issue:` (categorization should use labels)",
+        "Title is human-readable and concise (roughly 3-10 words, under ~60 chars)",
         "Includes a --body flag with meaningful content (steps to reproduce or context)",
         "Uses `--assignee @me` or equivalent to assign to the current user",
         "Checks the git remote to confirm it's a GitHub project before running gh commands",
@@ -181,6 +184,62 @@
         "Does NOT use a generic title like 'Add new feature' or just restate the user's request verbatim",
         "Uses `--reviewer elena` to request review",
         "Pushes the branch before creating the PR"
+      ]
+    },
+    {
+      "id": 14,
+      "prompt": "Create a GitHub issue for me: our checkout page is loading really slowly on mobile devices, takes about 8 seconds to render. Probably related to the new image carousel we added. High priority.",
+      "expected_output": "Human-readable title (e.g. 'Slow checkout page on mobile'). No CC format, no Bug:/Feature: prefix.",
+      "files": [],
+      "assertions": [
+        "Uses `gh issue create` with a --title flag",
+        "Title does NOT start with a Conventional Commits type prefix (no `feat:`, `fix:`, `perf:`, `chore:`, etc.)",
+        "Title does NOT contain a scoped CC prefix like `fix(checkout):` or `perf(mobile):`",
+        "Title does NOT start with `Bug:`, `Feature:`, `Task:`, `Issue:` pseudo-prefix",
+        "Title is human-readable and concise (3-10 words, under ~60 chars)",
+        "Title references checkout, mobile, or slowness in plain English"
+      ]
+    },
+    {
+      "id": 15,
+      "prompt": "Open an issue on our GitHub project: we should add dark mode support to the dashboard. The design team has been asking for it. It's a feature request, label it accordingly.",
+      "expected_output": "Human-readable title like 'Dark mode for dashboard'. No `feat:` or `Feature:` prefix.",
+      "files": [],
+      "assertions": [
+        "Uses `gh issue create` with a --title flag",
+        "Title does NOT start with a Conventional Commits type prefix (no `feat:`)",
+        "Title does NOT contain a scoped CC prefix like `feat(dashboard):` or `feat(ui):`",
+        "Title does NOT start with `Feature:`, `Feat:`, `Task:` pseudo-prefix",
+        "Title is human-readable and concise (3-10 words, under ~60 chars)",
+        "Title references dark mode and/or the dashboard in plain English"
+      ]
+    },
+    {
+      "id": 16,
+      "prompt": "File a GitHub issue: we need to bump our outdated npm dependencies, several have security advisories. Not super urgent but should be done this sprint.",
+      "expected_output": "Human-readable title. No `chore:` or `chore(deps):` prefix.",
+      "files": [],
+      "assertions": [
+        "Uses `gh issue create` with a --title flag",
+        "Title does NOT start with a Conventional Commits type prefix (no `chore:`, `build:`)",
+        "Title does NOT contain any scoped CC prefix like `chore(deps):`",
+        "Title does NOT start with `Chore:`, `Task:`, `Maintenance:` pseudo-prefix",
+        "Title is human-readable and concise (3-10 words, under ~60 chars)",
+        "Title mentions dependencies/npm/security in plain English"
+      ]
+    },
+    {
+      "id": 17,
+      "prompt": "Create a GitHub issue: our API rate limiting documentation is out of date -- it still references the old 100 req/min limit but we changed it to 500 req/min last quarter. Someone needs to fix the docs.",
+      "expected_output": "Human-readable title. No `docs:` or `docs(api):` prefix.",
+      "files": [],
+      "assertions": [
+        "Uses `gh issue create` with a --title flag",
+        "Title does NOT start with a Conventional Commits type prefix (no `docs:`, `fix:`)",
+        "Title does NOT contain any scoped CC prefix",
+        "Title does NOT start with `Docs:`, `Documentation:`, `Bug:` pseudo-prefix",
+        "Title is human-readable and concise (3-10 words, under ~60 chars)",
+        "Title mentions rate limiting documentation in plain English"
       ]
     }
   ]


### PR DESCRIPTION
Mirror the glab fix on the gh skill: GitHub issue titles were being produced in Conventional Commits format (`chore(deps): ...`, `docs: ...`) instead of human-readable noun phrases. Issue titles describe what the issue is about and are read on boards and in notifications; commit-shaped titles are premature (the solution is often unknown when the issue is filed) and harder to scan.

Adds a `## Issues` H2 heading (previously the issue subsections were orphan H3s) and an "Issue title format" subsection with style rules and a bad/good examples table. Replaces the misleading `"Bug: ..."` example in the issue commands block. Adds four eval cases (#14-#17) covering bug/feature/chore/docs prompts and augments eval #1 with title-format assertions. Eval run: 25/25 (100%) on the patched skill vs 21/25 (84%) on the pre-fix snapshot. CHANGELOG entry added under [Unreleased] / Fixed.

Assisted-by: claude-code/claude-opus-4-7