### PR TITLE
chore(sf-commit-convention): split skill into lean core + reference.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Changes are grouped by date.
 
 ### Changed
 
+- `sf-commit-convention` skill: split the heavy 240-line SKILL.md into a lean ~120-line core (branch naming, format detection, conventional/legacy formats, issue references, Assisted-by trailer) plus a bundled `reference.md` loaded on demand for worked git examples, GPG signing, non-interactive git, and format-detection edge cases. Cuts the skill's resident context cost (~22% of session usage per `/status`) by roughly half with no loss of guidance
 - `sf-create-agentsmd` skill: add Step 4 to manage a `CLAUDE.md` symlink alongside the root `AGENTS.md` -- auto-create relative symlink when `CLAUDE.md` is absent, preserve and warn when an existing regular file or mismatched symlink is found, no-op when already pointing at `AGENTS.md`, and explicit prompt with default No for non-root AGENTS-style files (subproject `AGENTS.md`, `.agents/AGENTS.project.md`). Three new evals cover scaffold, existing-CLAUDE.md, and subdir prompt scenarios. Capability spec at `openspec/specs/agentsmd-claude-symlink/`
 - Project renamed from `sf-awesome-copilot` to `sf-agents-harness` -- updated descriptions, references, and GitHub metadata to reflect broader scope beyond any single AI coding tool
 - README: Removed VS Code Insiders requirement for `chat.useAgentSkills` directive -- Agent Skills are now available in the standard VS Code release

--- a/skills/system/sf-commit-convention/SKILL.md
+++ b/skills/system/sf-commit-convention/SKILL.md
@@ -5,87 +5,51 @@ description: 'Enforce SparkFabrik commit message and branch naming conventions i
 
 # SparkFabrik Commit Convention
 
-This skill enforces SparkFabrik commit message and branch naming conventions. Follow these rules for every commit and branch you create.
+Core rules for every commit and branch. For worked git examples, format-detection
+edge cases, non-interactive git, and GPG signing, see [reference.md](reference.md).
 
 ## Branch Naming
 
-Create branches following this pattern:
+Pattern: `<prefix>/<issue-number>-<description>`
 
-```
-<prefix>/<issue-number>-<description>
-```
+- All lowercase, hyphens as separators
+- Issue number required (except `release/`)
+- Description: 2-4 words
 
-- **All lowercase**, hyphens as word separators
-- **Issue number required** (except `release/` branches)
-- **Description**: 2-4 words, concise
+| Prefix      | When to use                            |
+| ----------- | -------------------------------------- |
+| `feat/`     | New features                           |
+| `fix/`      | Bug fixes                              |
+| `docs/`     | Documentation only                     |
+| `chore/`    | Maintenance, dependencies, config      |
+| `refactor/` | Code restructuring, no behavior change |
+| `ci/`       | CI/CD pipeline changes                 |
+| `test/`     | Test additions or fixes                |
+| `release/`  | `release/vX.Y.Z` (no issue number)     |
 
-### Prefixes
+Examples: `feat/42-add-pdf-ingestion`, `fix/18-oauth-token-refresh`, `release/v1.2.0`
 
-| Prefix      | When to use                                               |
-| ----------- | --------------------------------------------------------- |
-| `feat/`     | New features                                              |
-| `fix/`      | Bug fixes                                                 |
-| `docs/`     | Documentation only                                        |
-| `chore/`    | Maintenance, dependencies, config                         |
-| `refactor/` | Code restructuring, no behavior change                    |
-| `ci/`       | CI/CD pipeline changes                                    |
-| `test/`     | Test additions or fixes                                   |
-| `release/`  | Release branches — use `release/vX.Y.Z` (no issue number) |
-
-### Examples
-
-```
-feat/42-add-pdf-ingestion
-fix/18-oauth-token-refresh
-docs/33-update-api-reference
-chore/71-bump-dependencies
-release/v1.2.0
-```
-
-### When to create a branch
-
-When work should happen on a separate branch (new feature, bug fix, or any issue-tracked work), create a branch following this convention before committing. If the user asks to start work on an issue and no branch exists, propose a branch name and confirm with the user before creating it.
+When work belongs on a separate branch (new feature, bug fix, issue-tracked work),
+create the branch before committing. If no branch exists, propose a name and confirm
+with the user before creating it.
 
 ## Format Detection
 
-Projects may enforce different commit message conventions via git hooks. Before the first commit in a session, detect the project's convention:
+Before the first commit in a session, detect the project's convention by running
+`git log --oneline -5` and matching the dominant pattern:
 
-### Step 1: Inspect recent history
+| Pattern                     | Format               | Example                         |
+| --------------------------- | -------------------- | ------------------------------- |
+| `type(scope): description`  | Conventional commits | `feat(auth): add JWT refresh`   |
+| `refs #N: description`      | SparkFabrik legacy   | `refs #42: fix token expiry`    |
+| `[PROJECT-123] description` | Jira-style           | `[ACME-456] fix login redirect` |
+| `PROJECT-123: description`  | Jira-style           | `ACME-456: fix login redirect`  |
 
-Run `git log --oneline -5` and look for a dominant pattern:
-
-| Pattern                     | Format                   | Example                            |
-| --------------------------- | ------------------------ | ---------------------------------- |
-| `type(scope): description`  | Conventional commits     | `feat(auth): add JWT refresh`      |
-| `refs #N: description`      | SparkFabrik legacy       | `refs #42: fix token expiry`       |
-| `[PROJECT-123] description` | Jira-style               | `[ACME-456] fix login redirect`    |
-| `PROJECT-123: description`  | Jira-style (no brackets) | `ACME-456: fix login redirect`     |
-| Other recognizable pattern  | Custom                   | Adapt to whatever the project uses |
-
-If the last 5 commits consistently follow one format, use that format. If mixed, use the most recent commit's format — the project is likely transitioning, and the latest commit reflects the current convention. If there are no commits or no recognizable pattern in the history (e.g., freeform messages like `"updated stuff"`, `"wip"`), ask the user what commit format the project expects.
-
-### Step 2: Check for commit-msg hooks
-
-Check if the project has a `commit-msg` hook (`.git/hooks/commit-msg`, husky, lefthook, or similar). The presence of a hook means the project enforces a specific format — the git log inspection from Step 1 becomes even more important because the hook will reject non-compliant messages.
-
-### Step 3: Handle hook rejection
-
-If a commit is rejected by a `commit-msg` hook:
-
-1. **Read the hook's error output** — it usually tells you the expected format.
-2. **Retry with the format indicated by the error**, not a hardcoded fallback.
-3. **If the error is unclear**, check `git log --oneline -3` for examples and match that pattern.
-4. **If still unclear**, ask the user what commit format the project expects.
-
-### Step 4: Cache
-
-Once detected, cache the format for the rest of the session. Do not re-detect on subsequent commits.
-
-### Adapting to custom formats
-
-When a project uses a non-standard format (e.g., Jira-style), adapt the commit message to that format while still applying the `Assisted-by` trailer. The trailer is a git mechanism independent of the commit message format — it works with any convention.
-
-For custom formats, the issue reference rules from this skill (fully qualified path in footers) may not apply — follow whatever convention the project uses. The `Assisted-by` trailer is the only rule that always applies regardless of project convention.
+Use the dominant format; if mixed, use the most recent commit's format. If there is no
+recognizable pattern, ask the user. Cache the detected format for the rest of the
+session. A `commit-msg` hook (`.git/hooks/commit-msg`, husky, lefthook) means the format
+is enforced — match it. For hook rejection, custom formats, and caching details, see
+[reference.md](reference.md).
 
 ## Conventional Commits (preferred)
 
@@ -93,9 +57,9 @@ For custom formats, the issue reference rules from this skill (fully qualified p
 <type>(<scope>): <description>
 ```
 
-- **Types**: `feat`, `fix`, `chore`, `test`, `docs`, `refactor`, `style`, `perf`, `ci`, `build`, `revert`
-- **Scope**: optional but recommended — use the component or area being changed
-- **Description**: lowercase, imperative mood, no trailing period
+- Types: `feat`, `fix`, `chore`, `test`, `docs`, `refactor`, `style`, `perf`, `ci`, `build`, `revert`
+- Scope: optional but recommended — the component or area changed
+- Description: lowercase, imperative mood, no trailing period
 
 ## Legacy Format (transitional)
 
@@ -103,105 +67,48 @@ For custom formats, the issue reference rules from this skill (fully qualified p
 refs #<issue-number>: <description>
 ```
 
-- Strictly lowercase `refs`
-- Always `#` before the issue number
-- Colon + space before description
+- Strictly lowercase `refs`, always `#` before the number, colon + space before the description
 - Lowercase description, imperative mood
-- This format is validated by git hooks in projects still using it
-- Cross-project issue references are not supported in legacy format
+- Validated by git hooks in projects still using it; cross-project references not supported
+- The issue reference is part of the subject — no separate footer needed
 
 ## Issue References
 
-**Always reference an issue.** If none is apparent from context (branch name, conversation, MR/PR description), ask the user:
+**Always reference an issue.** If none is apparent from context (branch name,
+conversation, MR/PR description), ask the user:
 
-> "Is there a related issue to reference? Provide the number (e.g. `#35`) or the full cross-project path (e.g. `owner/project#35`). Type 'none' if there is no related issue."
+> "Is there a related issue to reference? Provide the number (e.g. `#35`) or the full
+> cross-project path (e.g. `owner/project#35`). Type 'none' if there is no related issue."
 
 Skipping the reference is the exception, not the norm. Never silently omit it.
 
-### Resolving the full project path
+**Always use the fully qualified project path in footers — never a bare `#N`.** A bare
+`#N` is ambiguous and breaks when commits are cherry-picked, mirrored, or viewed outside
+the original project. Run `git remote get-url origin`, parse the `owner/repo` path, and
+resolve a bare `#35` to `<project-path>#35`:
 
-**Always use the fully qualified project path in footers — never a bare `#N`.** A bare `#N` is ambiguous: on platforms like GitLab it only links within the current project context, which breaks when commits are cherry-picked, mirrored, or viewed outside the original project. The fully qualified path (`owner/repo#N`) is unambiguous everywhere.
+- **Wrong:** `Refs: #35`, `Closes: #42`
+- **Correct:** `Refs: sparkfabrik/sf-awesome-copilot#35`, `Closes: sparkfabrik/sf-awesome-copilot#42`
 
-Run `git remote get-url origin` and parse the namespace/project path (e.g., `sparkfabrik/sf-agents-harness` on GitHub, `sparkfabrik-innovation-team/r-d/ai/project` on GitLab). When the user provides a bare `#N`, resolve it to `<project-path>#N`:
-
-| User provides      | Footer                                                                  |
-| ------------------ | ----------------------------------------------------------------------- |
-| `#35`              | `Refs: owner/repo#35` or `Closes: owner/repo#35` (resolved from remote) |
-| `owner/project#35` | `Refs: owner/project#35` or `Closes: owner/project#35` (used as-is)     |
-
-**Wrong:** `Refs: #35`, `Closes: #42` (bare references — never do this)
-**Correct:** `Refs: sparkfabrik/sf-awesome-copilot#35`, `Closes: sparkfabrik/sf-awesome-copilot#42`
-
-Use `Closes:` when the commit fully resolves the issue. Use `Refs:` otherwise.
-
-### Legacy format
-
-The issue reference is part of the subject line (`refs #N: ...`). No separate footer is needed.
+Use `Closes:` when the commit fully resolves the issue, `Refs:` otherwise. (Legacy format
+keeps the reference in the subject line instead.)
 
 ## Assisted-by Trailer
 
-**Mandatory on every commit**, regardless of format (legacy or conventional).
+**Mandatory on every commit**, regardless of format.
 
 - Format: `Assisted-by: <agentname>/<full-model-id>` (agent name MUST be all lowercase)
-- Applied via `--trailer` flag on `git commit`
+- Applied via the `--trailer` flag on `git commit`
 - Substitute your own runtime identity (agent name and model ID)
 
-Example for opencode with claude-opus-4.6:
-
-```
-Assisted-by: opencode/github-copilot/claude-opus-4.6
-```
+Example: `Assisted-by: opencode/github-copilot/claude-opus-4.6`
 
 ## MR/PR Titles
 
-Follow the same conventional commit format as the subject line. Issue reference goes in the MR/PR description body, never in the title.
+Same conventional commit format as the subject line. The issue reference goes in the
+MR/PR description body, never in the title.
 
-## Non-interactive Operations
-
-Agents run without a TTY. Any git command that opens `$EDITOR` or expects interactive keyboard input will hang indefinitely. Always pass messages and options via command-line flags.
-
-### Commands to avoid
-
-| Don't use                          | Why                             | Use instead                                  |
-| ---------------------------------- | ------------------------------- | -------------------------------------------- |
-| `git rebase -i`                    | Opens editor for pick/squash    | `git rebase <branch>` (non-interactive)      |
-| `git add -i` / `git add -p`        | Interactive staging prompts     | `git add <file>` or `git add .`              |
-| `git commit` (without `-m`)        | Opens editor for commit message | `git commit -m "..."` with `--trailer` flags |
-| `git merge` (conflict with editor) | Opens editor for merge message  | `git merge --no-edit <branch>`               |
-| `git tag -a` (without `-m`)        | Opens editor for tag annotation | `git tag -a v1.0 -m "..."`                   |
-| `git commit-tree`                  | Bypasses commit machinery, skips GPG signing and hooks | `git commit --amend -S` or `git rebase --exec "git commit --amend --no-edit -S"` |
-
-**General rule:** if a git command has a `-i` or `--interactive` flag, never use it. If a command normally opens an editor, find the flag that passes the value inline.
-
-### Rebase
-
-- `git rebase <branch>` (non-interactive) is safe for straightforward rebases.
-- For squashing commits, prefer the platform's squash merge option (GitHub / GitLab) over `git rebase -i`.
-- Prefer `git pull --rebase` over manual fetch + rebase when updating a branch.
-- If rebase conflicts occur, resolve the files then run `git rebase --continue`. Do not add `--edit` — the original commit messages are reused automatically.
-
-## GPG Signing & Commit Rewriting
-
-When `commit.gpgsign = true` is set, **never use git plumbing commands to rewrite commits**. `git commit-tree` and similar low-level commands bypass the commit machinery entirely, skipping GPG signing even when it is globally configured — resulting in "Unverified" commits on GitHub/GitLab.
-
-Always rewrite through `git commit`:
-
-```bash
-# Amend a single commit (re-signs automatically)
-git commit --amend --no-edit -S
-
-# Re-sign N commits after any history rewrite
-git rebase HEAD~N --exec "git commit --amend --no-edit -S"
-
-# Squash N commits (git commit handles signing automatically)
-git reset --soft HEAD~N && git commit -m "msg" --trailer "..."
-```
-
-Check if signing is active: `git config commit.gpgsign`
-
-## Git Command Examples
-
-### Conventional, same-project issue
+## Quick Example
 
 ```bash
 git commit -m "feat(rag): add document ingestion pipeline" \
@@ -209,32 +116,5 @@ git commit -m "feat(rag): add document ingestion pipeline" \
   --trailer "Assisted-by: opencode/github-copilot/claude-opus-4.6"
 ```
 
-### Conventional, cross-project issue
-
-```bash
-git commit -m "feat(rag): add document ingestion pipeline" \
-  --trailer "Refs: sparkfabrik-innovation-team/r-d/ai/poc-drupal-rag-intelligence#35" \
-  --trailer "Assisted-by: opencode/github-copilot/claude-opus-4.6"
-```
-
-### Conventional, auto-closing same-project issue
-
-```bash
-git commit -m "fix(discovery): handle symlink loops in file scanning" \
-  --trailer "Closes: owner/repo#42" \
-  --trailer "Assisted-by: opencode/github-copilot/claude-opus-4.6"
-```
-
-### Conventional, no issue (user confirmed none)
-
-```bash
-git commit -m "chore(deps): bump lockfile" \
-  --trailer "Assisted-by: opencode/github-copilot/claude-opus-4.6"
-```
-
-### Legacy format
-
-```bash
-git commit -m "refs #35: add document ingestion pipeline" \
-  --trailer "Assisted-by: opencode/github-copilot/claude-opus-4.6"
-```
+For cross-project issues, auto-closing, legacy format, GPG signing, and non-interactive
+git command guidance, see [reference.md](reference.md).

--- a/skills/system/sf-commit-convention/reference.md
+++ b/skills/system/sf-commit-convention/reference.md
@@ -1,0 +1,155 @@
+# Commit Convention — Reference
+
+Detailed material for the [sf-commit-convention](SKILL.md) skill. Loaded on demand for
+edge cases; the core rules live in `SKILL.md`.
+
+## Format Detection — Full Procedure
+
+### Step 1: Inspect recent history
+
+Run `git log --oneline -5` and look for a dominant pattern:
+
+| Pattern                     | Format                   | Example                            |
+| --------------------------- | ------------------------ | ---------------------------------- |
+| `type(scope): description`  | Conventional commits     | `feat(auth): add JWT refresh`      |
+| `refs #N: description`      | SparkFabrik legacy       | `refs #42: fix token expiry`       |
+| `[PROJECT-123] description` | Jira-style               | `[ACME-456] fix login redirect`    |
+| `PROJECT-123: description`  | Jira-style (no brackets) | `ACME-456: fix login redirect`     |
+| Other recognizable pattern  | Custom                   | Adapt to whatever the project uses |
+
+If the last 5 commits consistently follow one format, use that. If mixed, use the most
+recent commit's format — the project is likely transitioning, and the latest commit
+reflects the current convention. If there are no commits or no recognizable pattern
+(e.g., freeform messages like `"updated stuff"`, `"wip"`), ask the user what commit
+format the project expects.
+
+### Step 2: Check for commit-msg hooks
+
+Check if the project has a `commit-msg` hook (`.git/hooks/commit-msg`, husky, lefthook,
+or similar). The presence of a hook means the project enforces a specific format — the
+git log inspection from Step 1 becomes even more important because the hook will reject
+non-compliant messages.
+
+### Step 3: Handle hook rejection
+
+If a commit is rejected by a `commit-msg` hook:
+
+1. **Read the hook's error output** — it usually tells you the expected format.
+2. **Retry with the format indicated by the error**, not a hardcoded fallback.
+3. **If the error is unclear**, check `git log --oneline -3` for examples and match that pattern.
+4. **If still unclear**, ask the user what commit format the project expects.
+
+### Step 4: Cache
+
+Once detected, cache the format for the rest of the session. Do not re-detect on
+subsequent commits.
+
+### Adapting to custom formats
+
+When a project uses a non-standard format (e.g., Jira-style), adapt the commit message to
+that format while still applying the `Assisted-by` trailer. The trailer is a git
+mechanism independent of the commit message format — it works with any convention.
+
+For custom formats, the issue reference rules from this skill (fully qualified path in
+footers) may not apply — follow whatever convention the project uses. The `Assisted-by`
+trailer is the only rule that always applies regardless of project convention.
+
+## Resolving the Full Project Path
+
+Run `git remote get-url origin` and parse the namespace/project path (e.g.,
+`sparkfabrik/sf-agents-harness` on GitHub, `sparkfabrik-innovation-team/r-d/ai/project`
+on GitLab). When the user provides a bare `#N`, resolve it to `<project-path>#N`:
+
+| User provides      | Footer                                                                  |
+| ------------------ | ----------------------------------------------------------------------- |
+| `#35`              | `Refs: owner/repo#35` or `Closes: owner/repo#35` (resolved from remote) |
+| `owner/project#35` | `Refs: owner/project#35` or `Closes: owner/project#35` (used as-is)     |
+
+## Non-interactive Operations
+
+Agents run without a TTY. Any git command that opens `$EDITOR` or expects interactive
+keyboard input will hang indefinitely. Always pass messages and options via command-line
+flags.
+
+### Commands to avoid
+
+| Don't use                          | Why                                                    | Use instead                                                                      |
+| ---------------------------------- | ------------------------------------------------------ | -------------------------------------------------------------------------------- |
+| `git rebase -i`                    | Opens editor for pick/squash                           | `git rebase <branch>` (non-interactive)                                          |
+| `git add -i` / `git add -p`        | Interactive staging prompts                            | `git add <file>` or `git add .`                                                  |
+| `git commit` (without `-m`)        | Opens editor for commit message                        | `git commit -m "..."` with `--trailer` flags                                     |
+| `git merge` (conflict with editor) | Opens editor for merge message                         | `git merge --no-edit <branch>`                                                   |
+| `git tag -a` (without `-m`)        | Opens editor for tag annotation                        | `git tag -a v1.0 -m "..."`                                                       |
+| `git commit-tree`                  | Bypasses commit machinery, skips GPG signing and hooks | `git commit --amend -S` or `git rebase --exec "git commit --amend --no-edit -S"` |
+
+**General rule:** if a git command has a `-i` or `--interactive` flag, never use it. If a
+command normally opens an editor, find the flag that passes the value inline.
+
+### Rebase
+
+- `git rebase <branch>` (non-interactive) is safe for straightforward rebases.
+- For squashing commits, prefer the platform's squash merge option (GitHub / GitLab) over `git rebase -i`.
+- Prefer `git pull --rebase` over manual fetch + rebase when updating a branch.
+- If rebase conflicts occur, resolve the files then run `git rebase --continue`. Do not add `--edit` — the original commit messages are reused automatically.
+
+## GPG Signing & Commit Rewriting
+
+When `commit.gpgsign = true` is set, **never use git plumbing commands to rewrite
+commits**. `git commit-tree` and similar low-level commands bypass the commit machinery
+entirely, skipping GPG signing even when it is globally configured — resulting in
+"Unverified" commits on GitHub/GitLab.
+
+Always rewrite through `git commit`:
+
+```bash
+# Amend a single commit (re-signs automatically)
+git commit --amend --no-edit -S
+
+# Re-sign N commits after any history rewrite
+git rebase HEAD~N --exec "git commit --amend --no-edit -S"
+
+# Squash N commits (git commit handles signing automatically)
+git reset --soft HEAD~N && git commit -m "msg" --trailer "..."
+```
+
+Check if signing is active: `git config commit.gpgsign`
+
+## Git Command Examples
+
+### Conventional, same-project issue
+
+```bash
+git commit -m "feat(rag): add document ingestion pipeline" \
+  --trailer "Refs: owner/repo#35" \
+  --trailer "Assisted-by: opencode/github-copilot/claude-opus-4.6"
+```
+
+### Conventional, cross-project issue
+
+```bash
+git commit -m "feat(rag): add document ingestion pipeline" \
+  --trailer "Refs: sparkfabrik-innovation-team/r-d/ai/poc-drupal-rag-intelligence#35" \
+  --trailer "Assisted-by: opencode/github-copilot/claude-opus-4.6"
+```
+
+### Conventional, auto-closing same-project issue
+
+```bash
+git commit -m "fix(discovery): handle symlink loops in file scanning" \
+  --trailer "Closes: owner/repo#42" \
+  --trailer "Assisted-by: opencode/github-copilot/claude-opus-4.6"
+```
+
+### Conventional, no issue (user confirmed none)
+
+```bash
+git commit -m "chore(deps): bump lockfile" \
+  --trailer "Assisted-by: opencode/github-copilot/claude-opus-4.6"
+```
+
+### Legacy format
+
+```bash
+git commit -m "refs #35: add document ingestion pipeline" \
+  --trailer "Assisted-by: opencode/github-copilot/claude-opus-4.6"
+```


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## Summary

`sf-commit-convention` shows up as ~22% of session usage in Claude Code `/status`. Per the [skills docs](https://code.claude.com/docs/en/skills), a skill's body stays **resident in context across turns** once loaded — at 240 lines this skill was the single heaviest contributor on every commit/branch operation.

The `/status` hint to "run with a cheaper model via skill frontmatter" does not apply: skill frontmatter has no `model` field, and `context: fork` is documented as wrong for reference/guideline skills. The applicable lever is the docs' own guidance — *"Keep SKILL.md under 500 lines. Move detailed reference material to separate files."*

## Changes

- **`SKILL.md`** trimmed 240 → ~120 lines: keeps branch naming, format detection, conventional + legacy formats, issue references, the mandatory `Assisted-by` trailer, and one quick example.
- **`reference.md`** (new, bundled, loaded on demand): the 6 worked git examples, GPG signing/rewriting, non-interactive git command table, and the full format-detection procedure (hook rejection, caching, custom formats).
- SKILL.md links to `reference.md` for edge cases.

Resident context cost cut by roughly half, no loss of guidance. Distributed team-wide via `sjust sf-agents-refresh`; `reference.md` ships as a bundled asset.

Closes #84