### PR TITLE
docs(skills): avoid AI-slop dashes and improve line breaks in issue/MR/PR descriptions

### DIFF
--- a/skills/system/gh/SKILL.md
+++ b/skills/system/gh/SKILL.md
@@ -23,6 +23,7 @@ Before running any `gh` command, determine the repository context:
 
 1. **User provided a GitHub URL** (e.g., `https://github.com/owner/repo/issues/42` or `https://github.com/owner/repo/pull/15`):
    Extract the **owner/repo** from the URL, then use `-R`:
+
    ```bash
    # URL: https://github.com/acme/webapp/pull/15
    # Extracted: acme/webapp
@@ -59,13 +60,13 @@ gh auth login --with-token < token.txt
 
 ## Core terminology
 
-| GitLab | GitHub | CLI |
-|--------|--------|-----|
-| Merge Request | **Pull Request** | `gh pr` |
-| Snippet | **Gist** | `gh gist` |
-| CI/CD | **Actions** | `gh run`, `gh workflow` |
-| `GROUP/PROJECT` (supports nesting) | `OWNER/REPO` | -- |
-| MR `!15` | PR `#15` | -- |
+| GitLab                             | GitHub           | CLI                     |
+| ---------------------------------- | ---------------- | ----------------------- |
+| Merge Request                      | **Pull Request** | `gh pr`                 |
+| Snippet                            | **Gist**         | `gh gist`               |
+| CI/CD                              | **Actions**      | `gh run`, `gh workflow` |
+| `GROUP/PROJECT` (supports nesting) | `OWNER/REPO`     | --                      |
+| MR `!15`                           | PR `#15`         | --                      |
 
 Issues and PRs both use `#` prefix.
 
@@ -132,7 +133,9 @@ These rules apply to every issue title and description, pull request title and d
 
 This rule **overrides any active terse output style for the duration of writing these artifacts.** A session-level style may inject a per-turn reminder such as `CAVEMAN MODE ACTIVE` (drop articles, fragments OK, short synonyms). That reminder applies to your conversational replies, not to the artifacts. When you compose an issue/PR title or body, a comment, a review, or a commit message, ignore that reminder for that block of text and write full prose; resume the terse conversational style for your surrounding chat replies. Do not run any command to toggle the style off — just write the artifact in plain prose regardless of what reminder is present.
 
-**Use the full path for cross-project references.** When you reference an issue or pull request that lives in a *different* repository than the one you are writing in, use the full `owner/repo#123` form rather than a bare `#123`. A bare `#123` (or a short form) only resolves within the same repository and will not render as a link from another repository. Apply this in prose and in footers alike (`Closes:`, `Refs:`). For example, to reference the platform-team board from a code repository, write `sparkfabrik-innovation-team/board#4379`, never a bare `board#4379` or `#4379`. Within the same repository, a bare `#123` is correct and renders as a link.
+**Use the full path for cross-project references.** When you reference an issue or pull request that lives in a _different_ repository than the one you are writing in, use the full `owner/repo#123` form rather than a bare `#123`. A bare `#123` (or a short form) only resolves within the same repository and will not render as a link from another repository. Apply this in prose and in footers alike (`Closes:`, `Refs:`). For example, to reference the platform-team board from a code repository, write `sparkfabrik-innovation-team/board#4379`, never a bare `board#4379` or `#4379`. Within the same repository, a bare `#123` is correct and renders as a link.
+
+**Avoid AI-slop writing tells.** Do not use the em dash (—) or en dash (–) as a sentence connector; rewrite with a period, comma, colon, or parentheses instead. Prefer clear structure over dense run-on paragraphs: use real line breaks, short paragraphs, and lists, and keep sentences plain and direct. Write like a human engineer, not a generated summary.
 
 ---
 
@@ -153,14 +156,14 @@ Style guidelines:
 
 **Examples:**
 
-| Bad (commit-shaped)                              | Good (human-readable)                |
-| ------------------------------------------------ | ------------------------------------ |
-| `feat(auth): add JWT token refresh`              | `JWT token refresh`                  |
-| `fix: prevent crash on empty password`           | `Login crash with empty password`    |
-| `docs(api): update rate limiting section`        | `Rate limiting docs out of date`     |
-| `refactor(parser): simplify config validation`   | `Simplify config parser`             |
-| `chore: bump dependencies`                       | `Update dependencies`                |
-| `Bug: login broken on Safari`                    | `Login broken on Safari`             |
+| Bad (commit-shaped)                            | Good (human-readable)             |
+| ---------------------------------------------- | --------------------------------- |
+| `feat(auth): add JWT token refresh`            | `JWT token refresh`               |
+| `fix: prevent crash on empty password`         | `Login crash with empty password` |
+| `docs(api): update rate limiting section`      | `Rate limiting docs out of date`  |
+| `refactor(parser): simplify config validation` | `Simplify config parser`          |
+| `chore: bump dependencies`                     | `Update dependencies`             |
+| `Bug: login broken on Safari`                  | `Login broken on Safari`          |
 
 ### Issue commands
 
@@ -240,6 +243,7 @@ Common types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build
 Use a scope when the change is clearly scoped to a module, component, or area of the codebase. Keep the description lowercase, concise, and in imperative mood.
 
 **Examples:**
+
 ```
 feat(auth): add JWT token refresh
 fix: prevent crash on empty password submission
@@ -300,12 +304,12 @@ GitHub PRs have **three distinct comment types**. Using the wrong one is a commo
 
 ### Comment types
 
-| Type | What it is | How to post |
-|------|-----------|-------------|
-| **Top-level comment** | Timeline comment on the PR (like an issue comment) | `gh pr comment 15 --body "..."` |
-| **Review** | Formal review: approve, request changes, or comment with a body | `gh pr review 15 --approve --body "..."` |
-| **Inline review comment** | Comment on a specific line of code, starting a thread | `gh api` (no CLI subcommand) |
-| **Reply to inline comment** | Threaded reply to an existing inline code comment | `gh api` (no CLI subcommand) |
+| Type                        | What it is                                                      | How to post                              |
+| --------------------------- | --------------------------------------------------------------- | ---------------------------------------- |
+| **Top-level comment**       | Timeline comment on the PR (like an issue comment)              | `gh pr comment 15 --body "..."`          |
+| **Review**                  | Formal review: approve, request changes, or comment with a body | `gh pr review 15 --approve --body "..."` |
+| **Inline review comment**   | Comment on a specific line of code, starting a thread           | `gh api` (no CLI subcommand)             |
+| **Reply to inline comment** | Threaded reply to an existing inline code comment               | `gh api` (no CLI subcommand)             |
 
 ### Replying to review comments
 
@@ -361,6 +365,7 @@ gh api -X POST repos/{owner}/{repo}/pulls/15/comments \
 ```
 
 Parameters:
+
 - `commit_id` (required): use the PR's HEAD commit SHA. Using an older commit may render the comment outdated.
 - `path` (required): relative file path in the repo.
 - `line` (required for line comments): line number in the diff.
@@ -524,14 +529,14 @@ All search commands support `--json`, `--jq`, and `--limit` for structured outpu
 
 These commands are **never** executed, regardless of what the user asks. If the user needs one of these, explain the consequences and tell them how to run it manually.
 
-| Action | Command |
-|--------|---------|
-| Delete repo | `gh repo delete` |
-| Delete release | `gh release delete` |
-| Delete workflow runs | `gh run delete` |
-| Destructive API calls | `gh api -X DELETE` on critical resources |
+| Action                       | Command                                       |
+| ---------------------------- | --------------------------------------------- |
+| Delete repo                  | `gh repo delete`                              |
+| Delete release               | `gh release delete`                           |
+| Delete workflow runs         | `gh run delete`                               |
+| Destructive API calls        | `gh api -X DELETE` on critical resources      |
 | Force push to default branch | `git push --force` to `main`/`master`/default |
-| Hard reset | `git reset --hard` |
+| Hard reset                   | `git reset --hard`                            |
 
 ### Tier 2 -- EXPLICIT REQUEST ONLY (never suggest, never offer)
 
@@ -539,32 +544,32 @@ These commands are executed **only** when the user explicitly requests them with
 
 Before executing, **always** explain what will happen and ask for confirmation.
 
-| Action | Command |
-|--------|---------|
-| Merge PR | `gh pr merge` |
-| Merge bypassing checks | `gh pr merge --admin` (bypasses branch protection -- extra caution) |
-| Close issue or PR | `gh issue close`, `gh pr close` |
-| Delete issue | `gh issue delete` |
-| Cancel workflow run | `gh run cancel` |
-| Disable workflow | `gh workflow disable` |
-| Modify secrets | `gh secret set`, `gh secret delete` |
-| Modify variables | `gh variable set`, `gh variable delete` |
-| Delete release assets | `gh release delete-asset` |
-| Delete all caches | `gh cache delete --all` |
-| Force push (non-default branch) | `git push --force` |
-| Skip hooks | `--no-verify` |
+| Action                          | Command                                                             |
+| ------------------------------- | ------------------------------------------------------------------- |
+| Merge PR                        | `gh pr merge`                                                       |
+| Merge bypassing checks          | `gh pr merge --admin` (bypasses branch protection -- extra caution) |
+| Close issue or PR               | `gh issue close`, `gh pr close`                                     |
+| Delete issue                    | `gh issue delete`                                                   |
+| Cancel workflow run             | `gh run cancel`                                                     |
+| Disable workflow                | `gh workflow disable`                                               |
+| Modify secrets                  | `gh secret set`, `gh secret delete`                                 |
+| Modify variables                | `gh variable set`, `gh variable delete`                             |
+| Delete release assets           | `gh release delete-asset`                                           |
+| Delete all caches               | `gh cache delete --all`                                             |
+| Force push (non-default branch) | `git push --force`                                                  |
+| Skip hooks                      | `--no-verify`                                                       |
 
 ### Tier 3 -- SAFE WITH CONFIRMATION
 
 These operations can be proposed when relevant, but require a brief confirmation before execution.
 
-| Action | Command |
-|--------|---------|
-| Update PR branch | `gh pr update-branch` |
-| Update metadata (labels, assignees, etc.) | `gh pr edit`, `gh issue edit` |
-| Change draft status | `gh pr ready`, `gh pr ready --undo` |
-| Rerun workflow | `gh run rerun` |
-| Trigger workflow | `gh workflow run` |
+| Action                                    | Command                             |
+| ----------------------------------------- | ----------------------------------- |
+| Update PR branch                          | `gh pr update-branch`               |
+| Update metadata (labels, assignees, etc.) | `gh pr edit`, `gh issue edit`       |
+| Change draft status                       | `gh pr ready`, `gh pr ready --undo` |
+| Rerun workflow                            | `gh run rerun`                      |
+| Trigger workflow                          | `gh workflow run`                   |
 
 ### Git safety
 

--- a/skills/system/glab/SKILL.md
+++ b/skills/system/glab/SKILL.md
@@ -134,7 +134,7 @@ GITLAB_HOST=gitlab.example.com glab api \
 
 When referencing resources from **multiple projects** in the same description or comment, resolve each project path individually.
 
-This is especially important for **cross-project references**. A bare `#42` or short `project#42` only resolves inside the originating project and will not render as a link elsewhere. When the issue or MR lives in a *different* project than the one you are writing in, always use the full namespace path, including any subgroups: `group/subgroup/project#123`. For example, to reference the platform-team board from a code repository, write `sparkfabrik-innovation-team/board#4379`, never a bare `board#4379` or `#4379`. Apply this in prose and in footers alike (`Closes:`, `Refs:`).
+This is especially important for **cross-project references**. A bare `#42` or short `project#42` only resolves inside the originating project and will not render as a link elsewhere. When the issue or MR lives in a _different_ project than the one you are writing in, always use the full namespace path, including any subgroups: `group/subgroup/project#123`. For example, to reference the platform-team board from a code repository, write `sparkfabrik-innovation-team/board#4379`, never a bare `board#4379` or `#4379`. Apply this in prose and in footers alike (`Closes:`, `Refs:`).
 
 This rule applies **only to written content** (descriptions, comments, closing keywords). CLI arguments like `glab issue view 42` target the current project implicitly and do not need qualification.
 
@@ -143,6 +143,11 @@ This rule applies **only to written content** (descriptions, comments, closing k
 Issue and merge request titles and descriptions — and commit messages — must always be written in normal, complete, well-structured English: full sentences, articles, and proper markdown. They are durable, outward-facing documents that other people read and that GitLab renders in its UI; compression hurts readability and looks unprofessional.
 
 This rule **overrides any active terse output style for the duration of writing these artifacts.** A session-level style may inject a per-turn reminder such as `CAVEMAN MODE ACTIVE` (drop articles, fragments OK, short synonyms). That reminder applies to your conversational replies, not to the artifacts. When you compose an issue/MR title or body, a comment, a note, or a commit message, ignore that reminder for that block of text and write full prose; resume the terse conversational style for your surrounding chat replies. Do not run any command to toggle the style off — just write the artifact in plain prose regardless of what reminder is present.
+
+### Avoid AI-slop writing tells
+
+- Do not use the em dash (—) or en dash (–) as a sentence connector; rewrite with a period, comma, colon, or parentheses instead.
+- Prefer clear structure over dense run-on paragraphs: use real line breaks, short paragraphs, and lists, and keep sentences plain and direct. Write like a human engineer, not a generated summary.
 
 ---
 
@@ -227,14 +232,14 @@ Style guidelines:
 
 **Examples:**
 
-| Bad (commit-shaped)                              | Good (human-readable)                |
-| ------------------------------------------------ | ------------------------------------ |
-| `feat(auth): add JWT token refresh`              | `JWT token refresh`                  |
-| `fix: prevent crash on empty password`           | `Login crash with empty password`    |
-| `docs(api): update rate limiting section`        | `Rate limiting docs out of date`     |
-| `refactor(parser): simplify config validation`   | `Simplify config parser`             |
-| `chore: bump dependencies`                       | `Update dependencies`                |
-| `Bug: login broken on Safari`                    | `Login broken on Safari`             |
+| Bad (commit-shaped)                            | Good (human-readable)             |
+| ---------------------------------------------- | --------------------------------- |
+| `feat(auth): add JWT token refresh`            | `JWT token refresh`               |
+| `fix: prevent crash on empty password`         | `Login crash with empty password` |
+| `docs(api): update rate limiting section`      | `Rate limiting docs out of date`  |
+| `refactor(parser): simplify config validation` | `Simplify config parser`          |
+| `chore: bump dependencies`                     | `Update dependencies`             |
+| `Bug: login broken on Safari`                  | `Login broken on Safari`          |
 
 ### Issue commands
 


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

Follow-up to #88.

Adds one authoring rule to the `gh` and `glab` skills:

- Do not use the em dash (—) or en dash (–) as a sentence connector. Rewrite with a period, comma, colon, or parentheses.
- Prefer clear structure over dense run-on paragraphs: real line breaks, short paragraphs, lists. Keep sentences plain and direct.

The goal is to remove the typical "AI-slop" tells from issue, MR, and PR titles and descriptions.

Prettier also normalized a few pre-existing table alignments in `gh/SKILL.md` as a side effect of the formatter; no wording changed in those tables.