### PR TITLE
docs(glab): clarify refs must be bare to autolink, not backticked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Changes are grouped by date.
 - Project renamed from `sf-awesome-copilot` to `sf-agents-harness` -- updated descriptions, references, and GitHub metadata to reflect broader scope beyond any single AI coding tool
 - README: Removed VS Code Insiders requirement for `chat.useAgentSkills` directive -- Agent Skills are now available in the standard VS Code release
 - `glab` skill: require fully-qualified references (`group/project#N`, `group/project!N`) in all written content (descriptions, comments, notes) to prevent broken cross-project links
+- `glab` skill: clarify that references autolink only when written bare -- backticked refs render as inline code, and GitHub-style `owner/repo#N` does not autolink on GitLab; reconcile the duplicate "Issue auto-linking" note to point at the canonical rule
 - `glab` skill: auto-closing issues on merge via `Closes`/`Fixes` directives in MR descriptions is now optional -- the agent asks the user before including a closing reference, since auto-close is not always desired
 - `gh`, `glab`, and `sf-commit-convention` skills: consolidate the "write artifacts in plain prose" guidance into a single section per skill and state explicitly that an active terse output style (e.g. `CAVEMAN MODE ACTIVE`) does not apply to commit messages, MR/PR titles and descriptions, comments, or reviews -- these are always written in full prose
 

--- a/skills/system/glab/SKILL.md
+++ b/skills/system/glab/SKILL.md
@@ -136,6 +136,8 @@ When referencing resources from **multiple projects** in the same description or
 
 This is especially important for **cross-project references**. A bare `#42` or short `project#42` only resolves inside the originating project and will not render as a link elsewhere. When the issue or MR lives in a _different_ project than the one you are writing in, always use the full namespace path, including any subgroups: `group/subgroup/project#123`. For example, to reference the platform-team board from a code repository, write `sparkfabrik-innovation-team/board#4379`, never a bare `board#4379` or `#4379`. Apply this in prose and in footers alike (`Closes:`, `Refs:`).
 
+**Bare, not backticked.** A reference only autolinks when written bare. Wrapping it in backticks renders it as inline code, not a link, so keep file paths, flags, and identifiers in backticks but leave issue and merge request references bare. A GitHub-style reference such as `owner/repo#12` is not a GitLab project path and will not autolink on GitLab at all; use an explicit markdown link to the GitHub URL instead.
+
 This rule applies **only to written content** (descriptions, comments, closing keywords). CLI arguments like `glab issue view 42` target the current project implicitly and do not need qualification.
 
 ### Write in plain, professional prose
@@ -209,7 +211,7 @@ This applies to **every** piece of content the agent creates, regardless of leng
 > )"
 > ```
 
-> **Issue auto-linking:** GitLab renders bare `#N` as a clickable link to issue N. Use backticks (`` `#18` ``) when referring to issue numbers as text (examples, tables, logs). Leave `#N` bare only when it should link to an actual issue (e.g., `Closes #42`).
+> **Issue auto-linking:** GitLab renders a bare reference as a clickable link, but a backticked one renders as inline code and does not link. Use backticks when referring to a number as text (examples, tables, logs), and leave it bare when it should link to an actual issue (e.g., `Closes #42`). See "Fully-qualified references" above for the full rule, including cross-project paths and GitHub-style refs.
 
 ---
 


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## What

Clarify in the `glab` skill that an issue or MR reference autolinks on GitLab only when written **bare**. Wrapping it in backticks renders it as inline code, not a link.

## Why

The skill already requires fully-qualified cross-project paths (`group/subgroup/project#123`), but never said those refs must be bare to render. Backticking a cross-project ref produced a real broken link in a generated MR description. The skill also said nothing about GitHub-style refs (`owner/repo#N`), which do not autolink on GitLab at all.

## Change

- Added a **"Bare, not backticked"** clarification to the cross-project references guidance in `skills/system/glab/SKILL.md`: keep file paths, flags, and identifiers in backticks, but leave issue/MR references bare; a GitHub-style `owner/repo#N` is not a GitLab path and needs an explicit markdown link to the GitHub URL.
- Reconciled the duplicate "Issue auto-linking" note further down to restate the bare-vs-backtick rule and point at the canonical "Fully-qualified references" section.
- Added a concise CHANGELOG entry under `[Unreleased] > Changed`.

This prevents broken cross-project links in generated MR and issue descriptions.