### PR TITLE
docs(gh): expand skill description to improve trigger coverage

### DIFF
--- a/skills/system/gh/SKILL.md
+++ b/skills/system/gh/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gh
-description: 'How to use the GitHub CLI (gh) to work with GitHub issues, pull requests, Actions workflows, releases, and repositories. Use this skill whenever the user provides a URL containing "github.com" in the hostname, mentions pull requests, GitHub issues, GitHub Actions, or wants to interact with a GitHub remote. Also use this skill when the user mentions "gh", "PR", "pull request", or when you detect the git remote points to a GitHub instance (look for "github" in the remote URL). This skill is the GitHub equivalent of using `glab` for GitLab -- if the project is on GitHub, use this skill instead.'
+description: 'Invoke whenever the user is working with GitHub. Trigger on any of these signals: a URL containing "github.com" or a self-hosted GitHub Enterprise host, a git remote pointing to GitHub (git@github.com:... or https://github.com/...), the #N issue or PR notation (#15, #42), or words like "PR", "pull request", "gh", "GitHub issue", "GitHub Actions", "workflow run", "release", "gist", "review this PR", "merge this PR", "CI status", "checks", "fork", or "clone". Handles issues, pull requests, PR reviews and comments, GitHub Actions and CI runs, releases, gists, search, and reading files from GitHub repos. Always use gh, not WebFetch or curl, for any GitHub URL because gh handles authentication and returns structured data. This skill is the GitHub equivalent of glab for GitLab; if the project is on GitHub use this skill, and do not invoke it for GitLab tasks (use the glab skill instead).'
 ---
 
 # gh CLI Skill


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## What

Expands the `gh` skill frontmatter `description` so it auto-triggers more reliably when the user is doing GitHub work. Skill triggering depends only on the `description` field, so the change is scoped to that single line.

## Why

The previous description under-specified the activation signals relative to the sibling `glab` skill, causing the gh skill to under-trigger.

## Before

> How to use the GitHub CLI (gh) to work with GitHub issues, pull requests, Actions workflows, releases, and repositories. Use this skill whenever the user provides a URL containing "github.com" in the hostname, mentions pull requests, GitHub issues, GitHub Actions, or wants to interact with a GitHub remote. Also use this skill when the user mentions "gh", "PR", "pull request", or when you detect the git remote points to a GitHub instance (look for "github" in the remote URL). This skill is the GitHub equivalent of using `glab` for GitLab -- if the project is on GitHub, use this skill instead.

## After

> Invoke whenever the user is working with GitHub. Trigger on any of these signals: a URL containing "github.com" or a self-hosted GitHub Enterprise host, a git remote pointing to GitHub (git@github.com:... or https://github.com/...), the #N issue or PR notation (#15, #42), or words like "PR", "pull request", "gh", "GitHub issue", "GitHub Actions", "workflow run", "release", "gist", "review this PR", "merge this PR", "CI status", "checks", "fork", or "clone". Handles issues, pull requests, PR reviews and comments, GitHub Actions and CI runs, releases, gists, search, and reading files from GitHub repos. Always use gh, not WebFetch or curl, for any GitHub URL because gh handles authentication and returns structured data. This skill is the GitHub equivalent of glab for GitLab; if the project is on GitHub use this skill, and do not invoke it for GitLab tasks (use the glab skill instead).

## Reasoning

The new description adds the missing signals that the old one lacked: the `#N` issue and PR notation, concrete remote patterns, GitHub Enterprise hosts, common task verbs (review a PR, merge a PR, CI status, checks, workflow run, release, gist, fork, clone), the rule to prefer gh over WebFetch or curl for authenticated GitHub URLs, and a negative-disambiguation clause to avoid firing on GitLab tasks. Every added capability is already covered by the skill body (issues, pull requests, PR reviews and comments, Actions and CI, releases, search, gh api), so recall improves without over-broadening into unrelated tasks. The structure mirrors the richer `glab` description for consistency.

Closes #105


___

### **PR Type**
Documentation


___

### **Description**
- Expanded `gh` skill frontmatter `description` for better auto-triggering

- Added `#N` issue/PR notation, concrete remote URL patterns, and task verbs

- Added rule to prefer `gh` over `WebFetch` or `curl` for GitHub URLs

- Added negative disambiguation against GitLab tasks


___

### Diagram Walkthrough


```mermaid
flowchart LR
  old["Old description\n(under-specified signals)"]
  new["New description\n(comprehensive triggers)"]
  old -- "adds #N notation, remote patterns,\ntask verbs, tool preference rule,\nnegative disambiguation" --> new
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SKILL.md</strong><dd><code>Expand gh skill description for richer auto-trigger coverage</code></dd></summary>
<hr>

skills/system/gh/SKILL.md

<ul><li>Replaced the <code>description</code> frontmatter field with a significantly <br>expanded version<br> <li> Added <code>#N</code> issue/PR notation (e.g. <code>#15</code>, <code>#42</code>) as a trigger signal<br> <li> Added explicit GitHub remote URL patterns (<code>git@github.com:...</code>, <br><code>https://github.com/...</code>) and GitHub Enterprise mention<br> <li> Added common task verbs: "review this PR", "merge this PR", "CI <br>status", "checks", "workflow run", "release", "gist", "fork", "clone"<br> <li> Added rule to always use <code>gh</code> instead of <code>WebFetch</code> or <code>curl</code> for GitHub <br>URLs, and negative disambiguation against GitLab tasks</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sf-agents-harness/pull/106/files#diff-52d530ca4efb47a9e9d352ac179a3dd74b8436c2c82e5eac754e35558ff2eccc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

